### PR TITLE
add in axios for http requests

### DIFF
--- a/packages/react-scripts/scripts/utils/frontierInit.js
+++ b/packages/react-scripts/scripts/utils/frontierInit.js
@@ -54,6 +54,7 @@ function installFrontierDependencies(appPath, answers, useYarn, ownPath) {
     'http-proxy-middleware@0.19.0',
     'react-router-dom@4.3.1',
     'fs-webdev/exo',
+    'axios'
   ];
 
   const defaultDevModules = ['react-styleguidist@9.0.0-beta4', 'webpack@4.19.1'];


### PR DESCRIPTION
tldr; use axios instead of native fetch for http requests

1) native fetch handles errors poorly

For example, if you were to hit a page that does not exist, you would expect that fetch would throw. This is not the case. You would actually get back a resolved promise with a status of 400.

2) native fetch requires the user to manually convert response into something usable

3) axios is HUGELY OMEGA MASSIVELY used by the community. Its not very large, and it provides an incredible developer experience. Its fully tested, fully documented, and does everything FS.fetch is doing for us, plus more.

p.s. i don't know much about our auth yet, but yes, axios provides an easy way to attach headers to all requests so we don't have to manually authenticate each http call. I plan to learn more about this and provide something in lib that does that out of the box.