### PR TITLE
Restore Heroku prebuild

### DIFF
--- a/packages/react-scripts/scripts/utils/frontierInit.js
+++ b/packages/react-scripts/scripts/utils/frontierInit.js
@@ -139,6 +139,15 @@ function configureEF(appPath, ownPath, appName) {
   const templatePath = path.join(ownPath, 'template-ef');
   fs.copySync(templatePath, appPath, { overwrite: true });
 
+  alterPackageJsonFile(appPath, appPackage => {	
+    const packageJson = { ...appPackage };	
+    const additionalScripts = {	
+      'heroku-prebuild': './heroku-prebuild.sh',	
+    };	
+    packageJson.scripts = sortScripts({ ...packageJson.scripts, ...additionalScripts });	
+    return packageJson;	
+  });
+  
   depsToInstall.push(...['express@4.16.4']);
   replaceStringInFile(appPath, './blueprint.yml', /\{\{APP_NAME\}\}/g, appName)
 }


### PR DESCRIPTION
We need the auth in Heroku or the builds will fail. If this was supposed to be removed, then we need a buildpack or other solution.

