### PR TITLE
Copy over static assets from @fs and @fs-sandbox shared components.

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -538,6 +538,19 @@ module.exports = function(webpackEnv) {
       ],
     },
     plugins: [
+      // copy static assets from shared components
+      new CopyWebpackPlugin([
+        {
+          from: {
+            glob: path.join(
+              paths.appNodeModules,
+              `{@fs-sandbox,@fs}/**/dist/static/media/*`
+            ),
+          },
+          to: `static/media/[name].[ext]`,
+          toType: 'template',
+        },
+      ]),
       // FS - copy over hf's webpack built files to /static/hf directory to be
       // used by snow.
       isHF &&


### PR DESCRIPTION
This will copy any static assets created by webpack. (react-scripts's webpack config)