### PR TITLE
Update template to fix routing for home link

### DIFF
--- a/packages/react-scripts/template/src/components/App.js
+++ b/packages/react-scripts/template/src/components/App.js
@@ -9,7 +9,7 @@ function App() {
   return (
     <>
       <Subnav>
-        <Link to="/">
+        <Link to="./">
           <Trans i18nKey="nav.home">Home</Trans>
         </Link>
         <Link to="user">


### PR DESCRIPTION
`Link` needs to use a relative path in a nested router