### PR TITLE
Fix env fallback for int

### DIFF
--- a/packages/react-scripts/proxy/setupProxy.js
+++ b/packages/react-scripts/proxy/setupProxy.js
@@ -12,7 +12,7 @@ process.env.TARGET_ENV = env
 
 // set keys directly from fs-config for the current env
 function getFromEnv(thisEnv, key) {
-  return thisEnv === 'int' ? fsconfig.int[key] : fsconfig.default[key]
+  return fsconfig[thisEnv][key] || fsconfig.default[key]
 }
 const keys = ['FS_KEY', 'CIS_WEB']
 keys.forEach(key => {


### PR DESCRIPTION
REMOTE_ENV for int was not falling back correctly to default if the config var did not exist in int
This breaks auth when `REMOTE_ENV=int`