### PR TITLE
Add proxy to files in package.json

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -16,6 +16,7 @@
     "config",
     "lib",
     "scripts",
+    "proxy",
     "template*",
     "utils"
   ],


### PR DESCRIPTION
`proxy` dir isn't included when `npm installed`