### PR TITLE
Release 1.7.5 - Fix overrides dependencies  (#93)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ node_js:
   - 10
 before_install:
   - echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
-  - echo "//code.lds.org/artifactory/api/npm/npm-fhd/:_authToken=${NPM_PUBLISH_TOKEN}" >> .npmrc
-  - echo "@fs:registry=https://code.lds.org/artifactory/api/npm/npm-fhd/" >> .npmrc
+  - echo "//code.lds.org/artifactory/api/npm/npm-fhd/:_authToken=${NPM_PUBLISH_TOKEN}" >> ~/.npmrc
+  - echo "@fs:registry=https://code.lds.org/artifactory/api/npm/npm-fhd/" >> ~/.npmrc
     # because this is a weird monorepo and we cd into and out of directories, this is what worked for travis to publish
   - echo "//code.lds.org/artifactory/api/npm/npm-fhd/:_authToken=${NPM_PUBLISH_TOKEN}" >> packages/react-scripts/.npmrc
   - echo "@fs:registry=https://code.lds.org/artifactory/api/npm/npm-fhd/" >> packages/react-scripts/.npmrc
@@ -13,6 +13,15 @@ install:
   - "cd packages/react-scripts"
   - "npm i"
   - "cd ../../"
+script:
+  - npm test
+  # test that a new app can be created with these scripts
+  - mkdir -p ${HOME}/tmp && cd ${HOME}/tmp
+  - npx create-react-app my-test-app --use-npm --scripts-version file:${TRAVIS_BUILD_DIR}/packages/react-scripts/
+  - cd my-test-app
+  - CI=true npm test
+  - npm run build
+  - cd ${TRAVIS_BUILD_DIR}
 before_deploy: "cd packages/react-scripts"
 deploy:
   provider: npm

--- a/README-FRONTIER.md
+++ b/README-FRONTIER.md
@@ -5,10 +5,11 @@ That being said, if you want to use our fork "manually", then here is how you do
 
 1. Make sure you are authenticated with Artifactory
 
-- TODO: put those steps here or link to those steps
+   See https://beta.familysearch.org/frontier/docs/#/start/setup
 
-2. Run the following command  
-   `npx create-react-app {app-name} --scripts-version @fs/react-scripts`
+2. Run the following command
+
+   `npx create-react-app {app-name} --use-npm --scripts-version @fs/react-scripts`
 
 ## How to test your local copy of react-scripts
 
@@ -16,7 +17,7 @@ If you have cloned this repo and made changes locally and want to test them befo
 
 1. Clone this repo and make any changes needed in `./packages/react-scripts/`
 2. Run the following command  
-   `npx create-react-app ${yourNewAppsNameHere} --scripts-version file:${relativePathToYourClonedCreateReactAppRepo}/packages/react-scripts`
+   `npx create-react-app ${yourNewAppNameHere} --use-npm --scripts-version file:${relativePathToYourClonedCreateReactAppRepo}/packages/react-scripts`
 
 ## Development and Cutting a Release
 

--- a/packages/react-scripts/package-lock.json
+++ b/packages/react-scripts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "1.7.2",
+  "version": "1.7.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "upstreamVersion": "2.1.8",
   "description": "Configuration and scripts for Create React App.",
   "repository": "fs-webdev/create-react-app",

--- a/packages/react-scripts/scripts/utils/frontierInit.js
+++ b/packages/react-scripts/scripts/utils/frontierInit.js
@@ -21,6 +21,11 @@ const devDepsToInstall = [];
 
 async function promptForConfig() {
   console.log(fsCli.fsLogo('Frontier React Scripts'));
+  // when in CI, don't prompt, just accept defaults
+  if (process.env.CI === 'true') {
+    console.log('CI detected, skipping prompts and returning defaults ...');
+    return Promise.resolve({additionalFeatures: []});
+  }
   const questions = [
     {
       type: 'checkbox',
@@ -56,11 +61,11 @@ function installFrontierDependencies(appPath, appName, answers, ownPath) {
       '@fs/zion-router',
       '@fs/zion-subnav',
       '@fs/zion-error-boundary',
-      'http-proxy-middleware@0.19.1',
-      '@emotion/core@10.0.9',
-      'i18next@15.0.7',
-      'react-i18next@10.5.1',
-      'prop-types@15.7.2',
+      'http-proxy-middleware@0.19',
+      '@emotion/core@10',
+      'i18next@15',
+      'react-i18next@10',
+      'prop-types@15',
     ]
   );
   devDepsToInstall.push(
@@ -68,13 +73,13 @@ function installFrontierDependencies(appPath, appName, answers, ownPath) {
       '@fs/eslint-config-frontier-react',
       '@fs/zion-testing-library',
       'eslint@5.12.0',
-      'i18next-scanner@2.10.0',
-      '@alienfast/i18next-loader@1.0.18',
-      'react-styleguidist@9.0.4',
-      '@fs/styleguidist-overrides@1.3.0',
-      'dotenv@7.0.0',
-      'webpack@4.28.3',
-      'jest-dom@3.1.3',
+      'i18next-scanner@2',
+      '@alienfast/i18next-loader@1',
+      'react-styleguidist@9',
+      '@fs/styleguidist-overrides@1.3',
+      'dotenv@7',
+      'webpack@4',
+      'jest-dom@3',
     ]
   );
 
@@ -98,7 +103,7 @@ function installFrontierDependencies(appPath, appName, answers, ownPath) {
   installModulesSync(depsToInstall);
   installModulesSync(devDepsToInstall, true);
 
-  syncLocales()
+  syncLocales();
 
   replaceStringInFile(appPath, './README.md', /\{GITHUB_ORG\}\/\{GITHUB_REPO\}/g, `fs-webdev/${appName}`)
 }

--- a/packages/react-scripts/scripts/utils/osUtils.js
+++ b/packages/react-scripts/scripts/utils/osUtils.js
@@ -6,10 +6,13 @@ module.exports = {
   runExternalCommandSync,
 };
 
-function runExternalCommandSync(command, args) {
+function runExternalCommandSync(command, args, ignoreErrors = false) {
   const proc = spawn.sync(command, args, { stdio: 'inherit' });
   if (proc.status !== 0) {
-    console.error(`\`${command} ${args.join(' ')}\` failed`);
-    return;
+    const message = `\`${command} ${args.join(' ')}\` failed with status ${proc.status}`;
+    console.error(message);
+    if (!ignoreErrors) {
+      throw new Error(message);
+    }
   }
 }

--- a/packages/react-scripts/template/src/components/App.js
+++ b/packages/react-scripts/template/src/components/App.js
@@ -19,7 +19,7 @@ function App() {
 
       <Router>
         <Home path="/" />
-        <RequiresAuth path="/user" component={UserInfo} />
+        <RequiresAuth path="user" component={UserInfo} />
         <NotFound default />
       </Router>
     </>


### PR DESCRIPTION
* Update overrides dependencies
New apps were broken because it depends on non-zion-prefixed packages
Also made init fail if the npm installs fail
Remove leading slash on user route to make it a proper relative route
* add test for new app creation