### PR TITLE
Refactor REMOTE_ENV for deployed code

### DIFF
--- a/packages/react-scripts/proxy/setupProxy.js
+++ b/packages/react-scripts/proxy/setupProxy.js
@@ -1,36 +1,38 @@
 const proxy = require('http-proxy-middleware')
 const fsconfig = require('fs-config/config/default')
 
-/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable-next-line import/no-extraneous-dependencies */
 require('dotenv').config()
-/* eslint-enable import/no-extraneous-dependencies */
-
-// detect env
-const env = process.env.REMOTE_ENV || 'beta'
-// backwards compat for auth-middleware env implicit dependency
-process.env.TARGET_ENV = env
-
-// set keys directly from fs-config for the current env
-function getFromEnv(thisEnv, key) {
-  return fsconfig[thisEnv][key] || fsconfig.default[key]
-}
-const keys = ['FS_KEY', 'CIS_WEB']
-keys.forEach(key => {
-  process.env[key] = getFromEnv(env, key)
-})
-
-// dev key is only in default
-process.env.FS_DEV_KEY = fsconfig.default.FS_DEV_KEY
-
-// bring in auth middleware once required keys are set
-const cookieParser = require('cookie-parser')
-const base = require('connect-base')
-const metric = require('connect-metric')
-const auth = require('auth-middleware')
-const resolver = require('./resolver')
-const proxyList = require('./proxies')
 
 const setProxies = (app, customProxies = []) => {
+  // detect env
+  const env = process.env.REMOTE_ENV || 'beta'
+  // backwards compat for auth-middleware env implicit dependency
+  if (process.env.TARGET_ENV === 'local') {
+    process.env.TARGET_ENV = env
+  }
+
+  // set keys directly from fs-config for the current env
+  function getFromEnv(thisEnv, key) {
+    return fsconfig[thisEnv][key] || fsconfig.default[key]
+  }
+
+  const keys = ['FS_KEY', 'CIS_WEB']
+  keys.forEach(key => {
+    process.env[key] = getFromEnv(env, key)
+  })
+
+  // dev key is only in default
+  process.env.FS_DEV_KEY = fsconfig.default.FS_DEV_KEY
+
+  // bring in auth middleware once required keys are set
+  const cookieParser = require('cookie-parser')
+  const base = require('connect-base')
+  const metric = require('connect-metric')
+  const auth = require('auth-middleware')
+  const resolver = require('./resolver')
+  const proxyList = require('./proxies')
+
   // middleware required for auth middleware
   app.use(metric())
   app.use(base())


### PR DESCRIPTION
When deployed REMOTE_ENV config was overriding TARGET_ENV causing
apps to fail to work correctly outside of beta.
The scopes the env var overrides and other work to only happen when setProxies
is called and when in local dev mode, to remove impact on deployed apps

Tested by running locally with frontier-app-react and the proxies still worked fine. Need to confirm when deployed.

2 primary changes:
- All the logic around setting up the proxies was moved inside the `setProxies` call so it will not execute except when using the proxies. Previously it would execute when required, which happens even when not in dev mode
- As an extra measure of protection, TARGET_ENV is now only overridden if it equals `local`, so we only overwrite that value in local dev mode.