### PR TITLE
Remove REMOTE_ENV to fix all the things

### DIFF
--- a/packages/react-scripts/package-lock.json
+++ b/packages/react-scripts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "3.0.0-RC.2",
+  "version": "3.0.0-RC.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6052,10 +6052,6 @@
         "chalk": "^2.4.1"
       }
     },
-    "fs-config": {
-      "version": "github:fs-webdev/fs-config#d1601dd97b852a7f60cfd50355c18d38df229a14",
-      "from": "github:fs-webdev/fs-config"
-    },
     "fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -6167,9 +6163,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.6.tgz",
-      "integrity": "sha512-vfmKZp3XPM36DNF0qhW+Cdxk7xm7gTEHY1clv1Xq1arwRQuKZgAhw+NZNWbJBtuaNxzNXwhfdPYRrvIbjfS33A==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
+      "integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
       "optional": true
     },
     "function-bind": {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "3.0.0-RC.5",
+  "version": "3.0.0-RC.6",
   "upstreamVersion": "3.0.0",
   "description": "Configuration and scripts for Create React App.",
   "repository": {
@@ -66,7 +66,6 @@
     "file-loader": "3.0.1",
     "fork-ts-checker-webpack-plugin-alt": "0.4.14",
     "fs-cli-goodies": "github:fs-webdev/fs-cli-goodies",
-    "fs-config": "github:fs-webdev/fs-config",
     "fs-extra": "7.0.1",
     "html-webpack-plugin": "4.0.0-beta.5",
     "http-proxy-middleware": "^0.19.1",

--- a/packages/react-scripts/proxy/setupProxy.js
+++ b/packages/react-scripts/proxy/setupProxy.js
@@ -1,29 +1,11 @@
 const proxy = require('http-proxy-middleware')
-const fsconfig = require('fs-config/config/default')
 
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 require('dotenv').config()
 
 const setProxies = (app, customProxies = []) => {
   // detect env
-  const env = process.env.REMOTE_ENV || 'beta'
-  // backwards compat for auth-middleware env implicit dependency
-  if (process.env.TARGET_ENV === 'local') {
-    process.env.TARGET_ENV = env
-  }
-
-  // set keys directly from fs-config for the current env
-  function getFromEnv(thisEnv, key) {
-    return fsconfig[thisEnv][key] || fsconfig.default[key]
-  }
-
-  const keys = ['FS_KEY', 'CIS_WEB']
-  keys.forEach(key => {
-    process.env[key] = getFromEnv(env, key)
-  })
-
-  // dev key is only in default
-  process.env.FS_DEV_KEY = fsconfig.default.FS_DEV_KEY
+  const env = process.env.TARGET_ENV || 'local'
 
   // bring in auth middleware once required keys are set
   const cookieParser = require('cookie-parser')
@@ -45,7 +27,7 @@ const setProxies = (app, customProxies = []) => {
 
   // set default env target
   // prod auth keys don't exist in fs-config for security reasons, so only other alt-envs for now
-  const target = getFromEnv(env, 'BASE_URL')
+  const target = process.env.BASE_URL
 
   const setProxy = proxyConfig => {
     app.use(

--- a/packages/react-scripts/template/.storybook/middleware.js
+++ b/packages/react-scripts/template/.storybook/middleware.js
@@ -5,6 +5,6 @@ module.exports = router => {
   setupProxy(router)
 
   router.get('/dev-env', (req, res) => {
-    res.status(200).send({ environment: process.env.TARGET_ENV || 'beta' })
+    res.status(200).send({ environment: process.env.TARGET_ENV || 'local' })
   })
 }

--- a/packages/react-scripts/template/.storybook/middleware.js
+++ b/packages/react-scripts/template/.storybook/middleware.js
@@ -5,6 +5,6 @@ module.exports = router => {
   setupProxy(router)
 
   router.get('/dev-env', (req, res) => {
-    res.status(200).send({ environment: process.env.REMOTE_ENV || 'beta' })
+    res.status(200).send({ environment: process.env.TARGET_ENV || 'beta' })
   })
 }


### PR DESCRIPTION
## Problem:
- When frontier-react app runs locally, TARGET_ENV was set to 'beta', instead of 'local'
- This can cause several issues, but was noticed because local apps would only see changes made to 'beta' experiments on XPRMNTL

## Cause
- Core changed how they wanted to get vars into process after proxy was initially made, making .env/process.env and the way they cascade from fs-config from server the canonical truth, rather than direct vals in fs-config

## Solution
- Remove REMOTE_ENV usage and anywhere we're getting env vars directly from fs-config
- Remove where we were injecting them into process

## Testing
- npm linked @fs/react-scripts, made the changes
- used an fs-cra app, ran `fr env` in each env flag to set up .env locally
- tested that process.env.TARGET_ENV was 'local' in each
- tested that default proxy routes still worked as expected
- test that signin/signout still worked as expected