### PR TITLE
added /home proxy for upcoming outage banner component

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "3.0.0-RC.7",
+  "version": "3.0.0-RC.9",
   "upstreamVersion": "3.0.0",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/proxy/proxies.js
+++ b/packages/react-scripts/proxy/proxies.js
@@ -30,6 +30,9 @@ const proxies = [
     route: '/hf',
   },
   {
+    route: '/home',
+  },
+  {
     route: '/ident',
   },
   {

--- a/packages/react-scripts/proxy/proxies.js
+++ b/packages/react-scripts/proxy/proxies.js
@@ -30,7 +30,7 @@ const proxies = [
     route: '/hf',
   },
   {
-    route: '/home',
+    route: '/home/banner',
   },
   {
     route: '/ident',


### PR DESCRIPTION
Required by zion-outage-banner

Outage banner component will be loaded on every app from a global spot, so we'll need a proxy for the url it hits to get data, at /home/banner/currentBanner