### PR TITLE
Default to gzipped source map explorer sizes.

### DIFF
--- a/packages/react-scripts/scripts/utils/frontierInit.js
+++ b/packages/react-scripts/scripts/utils/frontierInit.js
@@ -132,7 +132,7 @@ function configureHF(appPath, ownPath) {
       'heroku-prebuild': './heroku-prebuild.sh',
       start: 'react-scripts start',
       'test:ci': 'CI=true react-scripts test --coverage',
-      analyzeBundle: "npm run build && source-map-explorer 'build/static/js/*.js'",
+      analyzeBundle: "npm run build && source-map-explorer 'build/static/js/*.js' --gzip",
     }
     packageJson.scripts = sortScripts({
       ...packageJson.scripts,


### PR DESCRIPTION
My PR finally got merged: https://github.com/danvk/source-map-explorer/pull/123

So now we can see gzipped file sizes in our bundle explorer.