### PR TITLE
Add Sentry config to app pages

### DIFF
--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -42,9 +42,11 @@
 
     <script>
       window.SERVER_DATA = {};
-      <%- typeof cacheKey !== 'undefined' ? `SERVER_DATA.cacheKey = '${cacheKey}';` : ''; %>
-      SERVER_DATA.appPath = "<%- typeof appPathOverride !== 'undefined' ? appPathOverride : appPath('') %>";
+      <%= typeof cacheKey !== 'undefined' ? `SERVER_DATA.cacheKey = '${cacheKey}';` : ''; %>
+      SERVER_DATA.appPath = "<%= typeof appPathOverride !== 'undefined' ? appPathOverride : appPath('') %>";
+      SERVER_DATA.targetEnv = "<%= process.env.TARGET_ENV %>""
       <% include partials/experiments %>
+      <% include partials/sentry %>
     </script>
   </head>
   <body>

--- a/packages/react-scripts/layout/views/partials/sentry.ejs
+++ b/packages/react-scripts/layout/views/partials/sentry.ejs
@@ -1,0 +1,9 @@
+<%
+const {APP_NAME, SENTRY_DSN, SENTRY_DISABLED, BUILD_GIT_CURRENT_SHA = '', BUILD_NUMBER } = process.env
+const sentryRelease = BUILD_NUMBER && BUILD_GIT_CURRENT_SHA ? `${APP_NAME}@${BUILD_NUMBER}:${BUILD_GIT_CURRENT_SHA.substring(0, 8)}` : ''
+%>
+<script>
+  SERVER_DATA.sentryDSN = '<%= SENTRY_DSN %>'
+  SERVER_DATA.sentryDisabled = <%= SENTRY_DISABLED === "true" %>
+  SERVER_DATA.sentryRelease = '<%= sentryRelease %>'
+</script>


### PR DESCRIPTION
Sets the following properties on `SERVER_DATA`:

- sentryDSN
- sentryDisabled
- sentryRelease
- targetEnv
 
`sentryRelease` is formatted like: 
`{appName}@{EFBuildNum}:{ShortGitSHAHash}`, i.e.
`frontier-app-react@172:6386b217`