### PR TITLE
Fix issue with --profile

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -322,7 +322,7 @@ module.exports = function(webpackEnv) {
         'react-native': 'react-native-web',
         // Allows for better profiling with ReactDevTools
         ...(isEnvProductionProfile && {
-          'react-dom$': 'react-dom/profiling',
+          'react-dom$': require.resolve('react-dom/profiling'),
           'scheduler/tracing': 'scheduler/tracing-profiling',
         }),
         react: require.resolve('react'),


### PR DESCRIPTION
When using --profile, there is an error that it can't find react-dom. This fixes that error.

Made change locally in node_modules and confirmed `npm run build:prod` worked without the error.