### PR TITLE
Remove deprecated doc instruction

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -191,8 +191,6 @@ Similar to `enzyme` you can create a `src/setupTests.js` file to avoid boilerpla
 
 ```js
 // react-testing-library renders your components to document.body,
-// this will ensure they're removed after each test.
-import '@testing-library/react/cleanup-after-each';
 // this adds jest-dom's custom assertions
 import '@testing-library/jest-dom/extend-expect';
 ```


### PR DESCRIPTION
This instruction is no longer necessary, so I removed it.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
