### PR TITLE
Add the path /dz in the proxy list

### DIFF
--- a/packages/react-scripts/proxy/proxies.js
+++ b/packages/react-scripts/proxy/proxies.js
@@ -19,32 +19,35 @@ const proxies = [
     accept: 'application/' /* 'application/x-gedcomx-v1+json', 'application/json', etc. */
   },
   {
-    route: '/ask',
+    route: '/ask'
   },
   {
-    route: '/cis-web',
+    route: '/cis-web'
   },
   {
-    route: '/frontier',
+    route: '/frontier'
   },
   {
-    route: '/hf',
+    route: '/hf'
   },
   {
-    route: '/home/banner',
+    route: '/home/banner'
   },
   {
-    route: '/ident',
+    route: '/ident'
   },
   {
-    route: '/mobile',
+    route: '/mobile'
   },
   {
-    route: '/platform',
+    route: '/platform'
   },
   {
-    route: '/service',
+    route: '/service'
   },
+  {
+    route: '/dz'
+  }
 ]
 
 module.exports = proxies


### PR DESCRIPTION
The RIP team is adding an image viewer component. We need urls proxied on the /dz path to load deep zoom images.