### PR TITLE
add crossorigin to manifest link for geo redirect

### DIFF
--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -15,7 +15,7 @@
     <meta name="google-site-verification" content="VJlFQrAXTCBy0PqVi23EsGD-mpA5KaBhIt8LkrcRbP0" />
     <link href="https://edge.fscdn.org/assets/docs/fs_logo_favicon_sq.png" rel="icon" type="image/x-icon" />
     <link rel="apple-touch-icon" href="https://edge.fscdn.org/assets/components/hf/assets/img/tree-touch-icon-11024a277f1fda5735de5a9f0f4f75ca.png" />
-    <link rel="manifest" href="<%= typeof appPathOverride !== 'undefined' ? appPathOverride : appPath('') %>/manifest.json"/>
+    <link rel="manifest" href="<%= typeof appPathOverride !== 'undefined' ? appPathOverride : appPath('') %>/manifest.json" type="application/manifest+json" crossorigin="use-credentials" />
 
     <!-- Resource Hints -->
     <link rel="preconnect" href="//edge.fscdn.org" crossorigin />

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "upstreamVersion": "4.0.3",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
The Geo redirect is breaking the loading of the manifest. According to https://stackoverflow.com/questions/51777346/cookies-not-sent-with-request-for-web-app-manifest-json if you set crossorigin even though the request is not crossorigin, it will allow the cookies to be sent with the request, fixing the geo redirect issue.

We tested this with the Africa geo app and it seems to work.