### PR TITLE
rename geodata to geoData for consistency

### DIFF
--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -49,7 +49,7 @@
       SERVER_DATA.baseUrl = "<%= process.env.BASE_URL %>"
       SERVER_DATA.sgBaseUrl = "<%= process.env.SG_BASE_URL %>"
       SERVER_DATA.splitioAuthKey = "<%= process.env.SPLITIO_AUTH_KEY %>"
-      SERVER_DATA.geodata = <%- typeof geodata !== 'undefined' ? JSON.stringify(geodata) : JSON.stringify({}) %>;
+      SERVER_DATA.geoData = <%- typeof geoData !== 'undefined' ? JSON.stringify(geoData) : JSON.stringify({}) %>;
       <% include partials/experiments %>
       <% include partials/sentry %>
     </script>

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "upstreamVersion": "4.0.3",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
after discussion, it was decided to use `geoData` instead of `geodata` for consistency with other similar variables