### PR TITLE
Release 6.2.0 - Support gql files and pin react error overlay

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,8 @@
+## 6.2.0
+
+Added support for .gql files
+Hard pin react-error-overlay to 6.0.9 to fix this issue: https://github.com/facebook/create-react-app/issues/11773
+
 ## 6.1.0
 
 Added polyfills for IntersectionObserver and ResizeObserver

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "6.2.0-beta.0",
+  "version": "6.2.0",
   "upstreamVersion": "4.0.3",
   "description": "Configuration and scripts for Create React App.",
   "repository": {
@@ -38,7 +38,8 @@
   "notes about dependencies and updates": {
     "@fs/auth-middleware": "snow can't handle auth-middleware at v3 yet.",
     "webpack": "webpack v4.44 and react-spring have a bad interaction, so don't go to 4.44",
-    "copy-webpack-plugin": "careful when updating this, the api HAS changed. npm run build in an app will show that there is an issue"
+    "copy-webpack-plugin": "careful when updating this, the api HAS changed. npm run build in an app will show that there is an issue",
+    "react-error-overlay": "hard pin to 6.0.9 to fix this issue until we move to CRA 5: https://github.com/facebook/create-react-app/issues/11773"
   },
   "dependencies": {
     "@alienfast/i18next-loader": "^1.0.18",
@@ -105,6 +106,7 @@
     "prompts": "2.4.0",
     "react-app-polyfill": "^2.0.0",
     "react-dev-utils": "^11.0.3",
+    "react-error-overlay": "6.0.9",
     "react-refresh": "^0.8.3",
     "resize-observer-polyfill": "^1.5.1",
     "resolve": "1.18.1",


### PR DESCRIPTION
Releases the support for gql files.

Due to this issue: https://github.com/facebook/create-react-app/issues/11773 we need to hard pin react-error-overlay to 6.0.9 as 6.0.10 does not work. 
