### PR TITLE
Perlocale tweaks

### DIFF
--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -18,28 +18,7 @@
     <link rel="manifest" href="<%= typeof appPathOverride !== 'undefined' ? appPathOverride : appPath('') %>/manifest.json" type="application/manifest+json" crossorigin="use-credentials" />
 
     <!-- Resource Hints -->
-    <link rel="preconnect" href="//edge.fscdn.org" crossorigin />
-
-    <% if (feature('appdynamicsFt') || process.env.APPDYNAMICS_ENABLED !== 'false') { %>
-      <script charset='UTF-8'>
-        window['adrum-start-time'] = new Date().getTime();
-        (function(config){
-          config.appKey = '<%= process.env.APPDYNAMICS_EUM_KEY %>';
-          config.adrumExtUrlHttps = 'https://cdn.appdynamics.com';
-          config.beaconUrlHttps = 'https://col.eum-appdynamics.com';
-          config.xd = {enable : true};
-          config.spa = {
-            "spa2": true
-          };
-        })(window['adrum-config'] || (window['adrum-config'] = {}));
-      </script>
-      <script src='https://cdn.appdynamics.com/adrum/adrum-latest.js' type='text/javascript' charset='UTF-8'></script>
-    <% } else if (feature('luxFt') || process.env.LUX_ENABLED === 'true') { %>
-      <script>
-        LUX=(function(){var a=("undefined"!==typeof(LUX)&&"undefined"!==typeof(LUX.gaMarks)?LUX.gaMarks:[]);var d=("undefined"!==typeof(LUX)&&"undefined"!==typeof(LUX.gaMeasures)?LUX.gaMeasures:[]);var j="LUX_start";var k=window.performance;var l=("undefined"!==typeof(LUX)&&LUX.ns?LUX.ns:(Date.now?Date.now():+(new Date())));if(k&&k.timing&&k.timing.navigationStart){l=k.timing.navigationStart}function f(){if(k&&k.now){return k.now()}var o=Date.now?Date.now():+(new Date());return o-l}function b(n){if(k){if(k.mark){return k.mark(n)}else{if(k.webkitMark){return k.webkitMark(n)}}}a.push({name:n,entryType:"mark",startTime:f(),duration:0});return}function m(p,t,n){if("undefined"===typeof(t)&&h(j)){t=j}if(k){if(k.measure){if(t){if(n){return k.measure(p,t,n)}else{return k.measure(p,t)}}else{return k.measure(p)}}else{if(k.webkitMeasure){return k.webkitMeasure(p,t,n)}}}var r=0,o=f();if(t){var s=h(t);if(s){r=s.startTime}else{if(k&&k.timing&&k.timing[t]){r=k.timing[t]-k.timing.navigationStart}else{return}}}if(n){var q=h(n);if(q){o=q.startTime}else{if(k&&k.timing&&k.timing[n]){o=k.timing[n]-k.timing.navigationStart}else{return}}}d.push({name:p,entryType:"measure",startTime:r,duration:(o-r)});return}function h(n){return c(n,g())}function c(p,o){for(i=o.length-1;i>=0;i--){var n=o[i];if(p===n.name){return n}}return undefined}function g(){if(k){if(k.getEntriesByType){return k.getEntriesByType("mark")}else{if(k.webkitGetEntriesByType){return k.webkitGetEntriesByType("mark")}}}return a}return{mark:b,measure:m,gaMarks:a,gaMeasures:d}})();LUX.ns=(Date.now?Date.now():+(new Date()));LUX.ac=[];LUX.cmd=function(a){LUX.ac.push(a)};LUX.init=function(){LUX.cmd(["init"])};LUX.send=function(){LUX.cmd(["send"])};LUX.addData=function(a,b){LUX.cmd(["addData",a,b])};LUX_ae=[];window.addEventListener("error",function(a){LUX_ae.push(a)});LUX_al=[];if("function"===typeof(PerformanceObserver)&&"function"===typeof(PerformanceLongTaskTiming)){var LongTaskObserver=new PerformanceObserver(function(c){var b=c.getEntries();for(var a=0;a<b.length;a++){var d=b[a];LUX_al.push(d)}});try{LongTaskObserver.observe({type:["longtask"]})}catch(e){}};
-      </script>
-      <script src="https://cdn.speedcurve.com/js/lux.js?id=371286048" async defer crossorigin="anonymous"></script>
-    <% } %>
+    <link rel="preconnect" href="https://edge.fscdn.org" crossorigin />
 
     <script>
       window.SERVER_DATA = {};

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -167,6 +167,6 @@
     ]
   },
   "publishConfig": {
-    "registry": "https://familysearch.jfrog.io/familysearch/api/npm/fs-npm-prod-virtual/"
+    "registry": "https://familysearch.jfrog.io/artifactory/api/npm/fs-npm-prod-virtual/"
   }
 }

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "7.0.0-beta.0",
+  "version": "7.0.0-beta.1",
   "upstreamVersion": "4.0.3",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/coalesceLocales.js
+++ b/packages/react-scripts/scripts/coalesceLocales.js
@@ -5,6 +5,7 @@ const path = require('path');
 const fs = require('fs');
 const rimraf = require('rimraf');
 const chokidar = require('chokidar');
+const _ = require('lodash')
 
 exports.coalesceLocales = paths => {
   console.time('per-locale coalesce');
@@ -22,30 +23,69 @@ exports.coalesceLocales = paths => {
     directory: paths.appPath,
     tsConfig: index.includes('.tsx') && `${paths.appPath}/tsconfig.json`,
     noTypeDefinitions: true, // optional
+    detective: {
+      es6: {
+        mixedImports: true
+      }
+    },
     nodeModulesConfig: {
       entry: 'module',
     },
-    filter: p => p.includes('src') || p.includes('@fs'),
+    filter: p => p.includes(paths.appSrc) || p.includes('@fs'),
   });
   const realList = list.filter(p => p.includes('locales/index.js'));
   const allLocales = {};
+  const collisionReport = {
+    collisions: [],
+    potentialCollisions: [],
+  }
+  const statsReport = {
+    namespaces: new Set(),
+    locales: new Set(),
+    keys: new Set(),
+  }
   realList.forEach(p => {
     const dir = path.dirname(p);
-    const locales = fs.readdirSync(dir).filter(d => !d.includes('.'));
+    // console.log('dir', dir)
+    const locales = fs.readdirSync(dir).filter(d => !d.includes('.') && d !== 'dist');
     locales.forEach(locale => {
+      statsReport.locales.add(locale)
       const namespaces = fs
         .readdirSync(path.join(dir, locale))
         .map(d => d.split('.')[0]);
       allLocales[locale] = allLocales[locale] || {};
       namespaces.forEach(ns => {
+        statsReport.namespaces.add(ns)
         const strings = jsonfile.readFileSync(
           `${path.join(dir, locale, ns)}.json`
         );
         allLocales[locale][ns] = allLocales[locale][ns] || {};
+        // console.log('strings', Object.keys(strings))
+        // console.log('allLocales', Object.keys(allLocales[locale][ns]||{}))
+        Object.keys(strings).map(key => statsReport.keys.add(key))
+        const collisions = _.intersection(Object.keys(allLocales[locale][ns]), Object.keys(strings))
+        if (collisions && collisions.length>0) {
+          collisions.forEach(collisionKey => {
+            if (allLocales[locale][ns][collisionKey] !== strings[collisionKey]) {
+              collisionReport.collisions.push({key:collisionKey,locale,ns,oldValue: allLocales[locale][ns][collisionKey], newValue: strings[collisionKey]})
+              // console.error(`COLLISION: key=${collisionKey} locale=${locale} namespace=${ns} "${strings[collisionKey]}" overrides "${allLocales[locale][ns][collisionKey]}"`)
+            } else {
+              collisionReport.potentialCollisions.push({key:collisionKey,locale,ns,oldValue: allLocales[locale][ns][collisionKey], newValue: strings[collisionKey]})
+            }
+          })
+        }
         allLocales[locale][ns] = { ...allLocales[locale][ns], ...strings };
       });
     });
   });
+  if (collisionReport.potentialCollisions.length > 0) {
+    console.warn(`WARNING: The following ${collisionReport.potentialCollisions.length} potential collisions were detected when coalescing locales, the values were the same, but could diverge in the future:`)
+    collisionReport.potentialCollisions.forEach(({ key, locale, ns, newValue }) => console.warn(`\tkey=${key} namespace=${ns} locale=${locale} value="${newValue}"`))
+  }
+  if (collisionReport.collisions.length > 0) {
+    console.error(`ERROR: The following ${collisionReport.collisions.length} collisions were detected when coalescing locales:`, collisionReport.collisions)
+    collisionReport.collisions.forEach(({ key, locale, ns, newValue, oldValue }) => console.error(`\tkey=${key} namespace=${ns} locale=${locale} newValue="${newValue}" oldValue="${oldValue}"`))
+  }
   Object.keys(allLocales).forEach(locale => {
     fs.mkdirSync(path.join(builtLocalesDir, locale));
     Object.keys(allLocales[locale]).forEach(namespace => {
@@ -57,6 +97,14 @@ exports.coalesceLocales = paths => {
   });
 
   console.timeEnd('per-locale coalesce');
+
+  console.log(`Locales Stats`, {
+    namespaces: statsReport.namespaces,
+    locales: statsReport.locales,
+    keys: statsReport.keys.size,
+  })
+  // console.dir(allLocales)
+  // throw new Error('boom')
 };
 
 exports.watchCoalesce = paths => {


### PR DESCRIPTION
Some tweaks and changes we can consider for per-locale
The logging could be opt-in or truncated for final release if we choose

It adds a collision report during coalesce so teams are aware of key collisions