### PR TITLE
Fix /coalesce-locales moduleNameMapper in jest tests.

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "upstreamVersion": "4.0.3",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -69,7 +69,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
       '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
-      '/coalesced-locales': path.resolve(path.join(paths.appSrc, 'locales')), // frontier
+      '/coalesced-locales': path.resolve(path.join(__dirname, 'jest.RawLoaderStub.js')), // frontier
       ...(modules.jestAliases || {}),
     },
     moduleFileExtensions: [...paths.moduleFileExtensions, 'node'].filter(

--- a/packages/react-scripts/scripts/utils/jest.RawLoaderStub.js
+++ b/packages/react-scripts/scripts/utils/jest.RawLoaderStub.js
@@ -1,0 +1,1 @@
+module.exports = ''


### PR DESCRIPTION
Mirror what we're doing in zion by just adding an empty module for jest.