### PR TITLE
restore dist behavior for npm start

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,6 @@
+## 8.0.0-rc.3
+- CRA 5 changed the default behavior so both prod and dev builds go to the `build` dir, which breaks our Snow middleware, so restoring the CRA 4 behavior that prod goes to `build` and dev goes to `dist`. We may revisit this later
+
 ## 8.0.0-rc.2
 - splitChunks was messing with output filename on development environment. Changing to use [file] instead of hardcoded filename
 

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -227,7 +227,7 @@ module.exports = function (webpackEnv) {
     entry: paths.appIndexJs,
     output: {
       // The build folder.
-      // Frontier: restoring CRA 4 behavior to keep build and dist separated
+      // Frontier: restoring CRA 4 behavior to keep prod on `build` and dev on `dist` which is the default if undefined since it works better with Snow today
       path: isEnvProduction ? paths.appBuild : undefined,
       // Add /* filename */ comments to generated require()s in the output.
       pathinfo: isEnvDevelopment,

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -227,7 +227,8 @@ module.exports = function (webpackEnv) {
     entry: paths.appIndexJs,
     output: {
       // The build folder.
-      path: paths.appBuild,
+      // Frontier: restoring CRA 4 behavior to keep build and dist separated
+      path: isEnvProduction ? paths.appBuild : undefined,
       // Add /* filename */ comments to generated require()s in the output.
       pathinfo: isEnvDevelopment,
       // There will be one main bundle, and one file per asynchronous chunk.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.0.0-rc.2",
+  "version": "8.0.0-rc.3",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
CRA5 updated this file without comment to always use `paths.appBuild` regardless of env settings. Our Snow middleware requires that the index file live in dist today, which is the webpack default if the output path is undefined. We could change our behavior to now use build like this code does, or we could restore the behavior where prod goes to build and dev goes to dist. After discussion with @joeycozza we think it's probably best to maintain our current pattern until we understand the potential ramification of sharing the `build` dir between both prod and dev builds.
Our experience has been that CRA devs don't really test with the `writeToDisk` flag like we use, so we find cases like this where they don't have sufficient information for us to know if this was intentional for good reasons or just tidying up some config, and since the default CRA dev builds are all in memory, the output dir won't matter until you set `writeToDisk` like we do.