### PR TITLE
adding "dir" to layout.ejs html element safely

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,7 @@
+## 8.1.0
+- adding `dir` property to html element in layout.ejs
+  - `dir` is set with `languageDir` defined in snow's res-locals.js middleware
+
 ## 8.0.2
 - allow fullySpecified: false for mjs files
   - Brought about because of this issue we had with @react-spring.

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= simpleLocale %>">
+<html dir="<%= typeof languageDir !== 'undefined' ? languageDir : 'ltr' %>" lang="<%= simpleLocale %>">
   <head>
     <title>FamilySearch.org</title>
 

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
adding "dir" for rlt support. Made sure to check typeof `languageDir` so if an app gets this update without the corresponding snow update, they won't be broken.