### PR TITLE
Release 8.1.1  - disable `runtimeErrors` in webpack-dev-server overlay

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,8 @@
+## 8.1.1
+- disable new `runtimeErrors` property in webpack-dev-server
+  - this causes constant errors with ResizeObserver
+  - requires webpack-dev-server 4.13.0
+
 ## 8.1.0
 - adding `dir` property to html element in layout.ejs
   - `dir` is set with `languageDir` defined in snow's res-locals.js middleware

--- a/package-lock.json
+++ b/package-lock.json
@@ -20027,6 +20027,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/launch-editor": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
+      "integrity": "sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "shell-quote": "^1.7.3"
+      }
+    },
     "node_modules/lerna": {
       "version": "4.0.0",
       "dev": true,
@@ -30857,8 +30866,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "4.11.1",
-      "license": "MIT",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.13.1.tgz",
+      "integrity": "sha512-5tWg00bnWbYgkN+pd5yISQKDejRBYGEw15RaEEslH+zdbNDxxaZvEAO2WulaSaFKb5n3YG8JXsGaDsut1D0xdA==",
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -30879,6 +30889,7 @@
         "html-entities": "^2.3.2",
         "http-proxy-middleware": "^2.0.3",
         "ipaddr.js": "^2.0.1",
+        "launch-editor": "^2.6.0",
         "open": "^8.0.9",
         "p-retry": "^4.5.0",
         "rimraf": "^3.0.2",
@@ -30888,7 +30899,7 @@
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",
         "webpack-dev-middleware": "^5.3.1",
-        "ws": "^8.4.2"
+        "ws": "^8.13.0"
       },
       "bin": {
         "webpack-dev-server": "bin/webpack-dev-server.js"
@@ -30904,6 +30915,9 @@
         "webpack": "^4.37.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        },
         "webpack-cli": {
           "optional": true
         }
@@ -30955,14 +30969,15 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.11.0",
-      "license": "MIT",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -32281,7 +32296,7 @@
     },
     "packages/react-scripts": {
       "name": "@fs/react-scripts",
-      "version": "8.0.1",
+      "version": "8.1.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -32348,7 +32363,7 @@
         "ts-pnp": "1.2.0",
         "url-loader": "4.1.1",
         "webpack": "^5.64.4",
-        "webpack-dev-server": "^4.6.0",
+        "webpack-dev-server": "^4.13.0",
         "webpack-manifest-plugin": "^4.0.2",
         "webpack-merge": "^4.2.1",
         "webpack-node-externals": "^1.7.2",
@@ -35768,7 +35783,7 @@
         "typescript": "^4.4.4",
         "url-loader": "4.1.1",
         "webpack": "^5.64.4",
-        "webpack-dev-server": "^4.6.0",
+        "webpack-dev-server": "^4.13.0",
         "webpack-manifest-plugin": "^4.0.2",
         "webpack-merge": "^4.2.1",
         "webpack-node-externals": "^1.7.2",
@@ -46956,6 +46971,15 @@
         "package-json": "^6.3.0"
       }
     },
+    "launch-editor": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
+      "integrity": "sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==",
+      "requires": {
+        "picocolors": "^1.0.0",
+        "shell-quote": "^1.7.3"
+      }
+    },
     "lerna": {
       "version": "4.0.0",
       "dev": true,
@@ -54148,7 +54172,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "4.11.1",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.13.1.tgz",
+      "integrity": "sha512-5tWg00bnWbYgkN+pd5yISQKDejRBYGEw15RaEEslH+zdbNDxxaZvEAO2WulaSaFKb5n3YG8JXsGaDsut1D0xdA==",
       "requires": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -54169,6 +54195,7 @@
         "html-entities": "^2.3.2",
         "http-proxy-middleware": "^2.0.3",
         "ipaddr.js": "^2.0.1",
+        "launch-editor": "^2.6.0",
         "open": "^8.0.9",
         "p-retry": "^4.5.0",
         "rimraf": "^3.0.2",
@@ -54178,7 +54205,7 @@
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",
         "webpack-dev-middleware": "^5.3.1",
-        "ws": "^8.4.2"
+        "ws": "^8.13.0"
       },
       "dependencies": {
         "ajv": {
@@ -54209,7 +54236,9 @@
           }
         },
         "ws": {
-          "version": "8.11.0",
+          "version": "8.13.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
           "requires": {}
         }
       }

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -92,6 +92,7 @@ module.exports = function (proxy, allowedHost) {
       overlay: {
         errors: true,
         warnings: false,
+        runtimeErrors: false,
       },
     },
     devMiddleware: {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {
@@ -111,7 +111,7 @@
     "ts-pnp": "1.2.0",
     "url-loader": "4.1.1",
     "webpack": "^5.64.4",
-    "webpack-dev-server": "^4.6.0",
+    "webpack-dev-server": "^4.13.0",
     "webpack-manifest-plugin": "^4.0.2",
     "webpack-merge": "^4.2.1",
     "webpack-node-externals": "^1.7.2",


### PR DESCRIPTION
webpack-dev-server 4.12.0 added a new feature to show runtime errors in the error overlay by default.
https://github.com/webpack/webpack-dev-server/pull/4605
This resulted in constant ResizeObserver errors in dev mode.
https://github.com/webpack/webpack-dev-server/issues/4771
They added a config for this in 4.13.0
https://github.com/webpack/webpack-dev-server/pull/4773
This uses that new config to disable that feature until we can filter the errors (https://github.com/webpack/webpack-dev-server/issues/4777) or fix ResizeObserver

Fixes FRONTIER-683