### PR TITLE
[react-scripts - coalesceLocales] Allow TS apps to use a src/index.js file

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/coalesceLocales.js
+++ b/packages/react-scripts/scripts/coalesceLocales.js
@@ -24,9 +24,7 @@ exports.coalesceLocales = paths => {
   const list = dependencyTree.toList({
     filename: index,
     directory: paths.appPath,
-    tsConfig:
-      (index.includes('.tsx') || fs.existsSync(paths.appTsConfig)) &&
-      paths.appTsConfig,
+    tsConfig: fs.existsSync(paths.appTsConfig) && paths.appTsConfig,
     noTypeDefinitions: true, // optional
     detective: { es6: { mixedImports: true } },
     nodeModulesConfig: { entry: 'module' },

--- a/packages/react-scripts/scripts/coalesceLocales.js
+++ b/packages/react-scripts/scripts/coalesceLocales.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fs = require('fs');
 const rimraf = require('rimraf');
 const chokidar = require('chokidar');
-const _ = require('lodash')
+const _ = require('lodash');
 
 exports.coalesceLocales = paths => {
   console.time('per-locale coalesce');
@@ -16,22 +16,20 @@ exports.coalesceLocales = paths => {
     rimraf.sync(builtLocalesDir);
   }
   fs.mkdirSync(builtLocalesDir);
-  
-  const index = fs.existsSync(`${paths.appSrc}/index.tsx`) ? `${paths.appSrc}/index.tsx` : `${paths.appSrc}/index.js`
-  
+
+  const index = fs.existsSync(`${paths.appSrc}/index.tsx`)
+    ? `${paths.appSrc}/index.tsx`
+    : `${paths.appSrc}/index.js`;
+
   const list = dependencyTree.toList({
     filename: index,
     directory: paths.appPath,
-    tsConfig: index.includes('.tsx') && `${paths.appPath}/tsconfig.json`,
+    tsConfig:
+      (index.includes('.tsx') || fs.existsSync(paths.appTsConfig)) &&
+      paths.appTsConfig,
     noTypeDefinitions: true, // optional
-    detective: {
-      es6: {
-        mixedImports: true
-      }
-    },
-    nodeModulesConfig: {
-      entry: 'module',
-    },
+    detective: { es6: { mixedImports: true } },
+    nodeModulesConfig: { entry: 'module' },
     filter: p => p.includes(paths.appSrc) || p.includes('@fs'),
   });
   const realList = list.filter(p => p.includes('locales/index.js'));
@@ -39,41 +37,60 @@ exports.coalesceLocales = paths => {
   const collisionReport = {
     collisions: [],
     potentialCollisions: [],
-  }
+  };
   const statsReport = {
     namespaces: new Set(),
     locales: new Set(),
     keys: new Set(),
-  }
+  };
   realList.forEach(p => {
     const dir = path.dirname(p);
     // console.log('dir', dir)
-    const locales = fs.readdirSync(dir).filter(d => !d.includes('.') && d !== 'dist');
+    const locales = fs
+      .readdirSync(dir)
+      .filter(d => !d.includes('.') && d !== 'dist');
     locales.forEach(locale => {
-      statsReport.locales.add(locale)
+      statsReport.locales.add(locale);
       const namespaces = fs
         .readdirSync(path.join(dir, locale))
         .map(d => d.split('.')[0]);
       allLocales[locale] = allLocales[locale] || {};
       namespaces.forEach(ns => {
-        statsReport.namespaces.add(ns)
+        statsReport.namespaces.add(ns);
         const strings = jsonfile.readFileSync(
           `${path.join(dir, locale, ns)}.json`
         );
         allLocales[locale][ns] = allLocales[locale][ns] || {};
         // console.log('strings', Object.keys(strings))
         // console.log('allLocales', Object.keys(allLocales[locale][ns]||{}))
-        Object.keys(strings).map(key => statsReport.keys.add(key))
-        const collisions = _.intersection(Object.keys(allLocales[locale][ns]), Object.keys(strings))
-        if (collisions && collisions.length>0) {
+        Object.keys(strings).map(key => statsReport.keys.add(key));
+        const collisions = _.intersection(
+          Object.keys(allLocales[locale][ns]),
+          Object.keys(strings)
+        );
+        if (collisions && collisions.length > 0) {
           collisions.forEach(collisionKey => {
-            if (allLocales[locale][ns][collisionKey] !== strings[collisionKey]) {
-              collisionReport.collisions.push({key:collisionKey,locale,ns,oldValue: allLocales[locale][ns][collisionKey], newValue: strings[collisionKey]})
+            if (
+              allLocales[locale][ns][collisionKey] !== strings[collisionKey]
+            ) {
+              collisionReport.collisions.push({
+                key: collisionKey,
+                locale,
+                ns,
+                oldValue: allLocales[locale][ns][collisionKey],
+                newValue: strings[collisionKey],
+              });
               // console.error(`COLLISION: key=${collisionKey} locale=${locale} namespace=${ns} "${strings[collisionKey]}" overrides "${allLocales[locale][ns][collisionKey]}"`)
             } else {
-              collisionReport.potentialCollisions.push({key:collisionKey,locale,ns,oldValue: allLocales[locale][ns][collisionKey], newValue: strings[collisionKey]})
+              collisionReport.potentialCollisions.push({
+                key: collisionKey,
+                locale,
+                ns,
+                oldValue: allLocales[locale][ns][collisionKey],
+                newValue: strings[collisionKey],
+              });
             }
-          })
+          });
         }
         allLocales[locale][ns] = { ...allLocales[locale][ns], ...strings };
       });
@@ -81,12 +98,25 @@ exports.coalesceLocales = paths => {
   });
   if (collisionReport.potentialCollisions.length > 0) {
     console.warn(`WARNING: There were ${collisionReport.potentialCollisions.length} potential collisions detected when coalescing locales, the values were the same, but could diverge in the future:
-      To see a list of all potential collisions, turn on debugging with "DEBUG=coalesceLocales" before the command you just ran `)
-    collisionReport.potentialCollisions.forEach(({ key, locale, ns, newValue }) => debug(`\tkey=${key} namespace=${ns} locale=${locale} value="${newValue}"`))
+      To see a list of all potential collisions, turn on debugging with "DEBUG=coalesceLocales" before the command you just ran `);
+    collisionReport.potentialCollisions.forEach(
+      ({ key, locale, ns, newValue }) =>
+        debug(
+          `\tkey=${key} namespace=${ns} locale=${locale} value="${newValue}"`
+        )
+    );
   }
   if (collisionReport.collisions.length > 0) {
-    console.error(`ERROR: The following ${collisionReport.collisions.length} collisions were detected when coalescing locales:`, collisionReport.collisions)
-    collisionReport.collisions.forEach(({ key, locale, ns, newValue, oldValue }) => console.error(`\tkey=${key} namespace=${ns} locale=${locale} newValue="${newValue}" oldValue="${oldValue}"`))
+    console.error(
+      `ERROR: The following ${collisionReport.collisions.length} collisions were detected when coalescing locales:`,
+      collisionReport.collisions
+    );
+    collisionReport.collisions.forEach(
+      ({ key, locale, ns, newValue, oldValue }) =>
+        console.error(
+          `\tkey=${key} namespace=${ns} locale=${locale} newValue="${newValue}" oldValue="${oldValue}"`
+        )
+    );
   }
   Object.keys(allLocales).forEach(locale => {
     fs.mkdirSync(path.join(builtLocalesDir, locale));
@@ -104,7 +134,7 @@ exports.coalesceLocales = paths => {
     namespaces: statsReport.namespaces,
     locales: statsReport.locales,
     keys: statsReport.keys.size,
-  })
+  });
   // console.dir(allLocales)
   // throw new Error('boom')
 };
@@ -117,10 +147,13 @@ exports.watchCoalesce = paths => {
     }
   );
 
-  watcher.on('all', _.debounce(() => {
-    console.log('Detected change to locales, recoalescing...');
-    exports.coalesceLocales(paths);
-  }, 250));
+  watcher.on(
+    'all',
+    _.debounce(() => {
+      console.log('Detected change to locales, recoalescing...');
+      exports.coalesceLocales(paths);
+    }, 250)
+  );
 
   ['SIGINT', 'SIGTERM'].forEach(function (sig) {
     process.on(sig, function () {


### PR DESCRIPTION
Don't just depend on an app using src/index.tsx to apply a tsconfig for getting the translations in deps.

Tested on tree-person-r9 with src/index.tsx and src/index.js to make sure that all translations come through and they do.

See https://familysearch.slack.com/archives/C0FPL3ZL7/p1681949517152119 for more information.

I found out about paths.appTsConfig because I had printed out paths to see what all was in there.