### PR TITLE
Release 8.1.2 - add window.dtinfo.appName for DT

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,6 @@
+## 8.1.2
+- add `window.dtinfo` with `appName` for Dynatrace integration
+
 ## 8.1.1
 - disable new `runtimeErrors` property in webpack-dev-server
   - this causes constant errors with ResizeObserver

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -35,6 +35,11 @@
       <% include partials/experiments %>
       <% include partials/sentry %>
       <% include partials/clientAppConfig %>
+      if (window.dtrum) {
+        window.dtrum.enableManualPageDetection()
+        if (!window.dtinfo) window.dtinfo = {}
+        window.dtinfo.appName = SERVER_DATA.appName
+      }
     </script>
   </head>
   <body>

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
This adds a `window.dtinfo.appName` variable for Dynatrace to consume to get the app name

This has been tested with prerelease 8.1.2-alpha.0 on frontier-app-react and tree-person-r9

FYI @jdsumsion 

