### PR TITLE
[coalesceLocales] Support jsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32296,7 +32296,7 @@
     },
     "packages/react-scripts": {
       "name": "@fs/react-scripts",
-      "version": "8.1.1",
+      "version": "8.2.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
Allow passing a jsconfig.json to dependencyTree's filing-cabinet so that the tree based on options from the jsconfig get passed on.

This fixes an issue where @fs package locales that weren't reached unless by absolute imports (made available by jsconfig) were not getting imported.

We have this for our jsconfig
```
{
  "compilerOptions": { "baseUrl": "src" },
  "include": ["src"]
}
```
and our App.js (which index.js references) only reaches our components using an absolute path:
`import GroupManagementPage from 'pages/GroupManagementPage'`

I verified this works by doing `npm start > log.txt` and logging out realList in coalesceLocales.

before this pr's changes:
Left is group-management master before we added jsconfig, right is group-management after we added jsconfig. Notice that @fs/zion-group-management and @fs/tree-controlled-edit-trees are missing.
![image](https://github.com/fs-webdev/create-react-app/assets/77301861/e512297b-548d-4923-9c19-b0cb50b74a8c)

after this pr's changes:
left is group-management master before we added jsconfig, right is group-management after we added jsconfig. 
![image](https://github.com/fs-webdev/create-react-app/assets/77301861/219f2dfc-c97e-43ad-ad31-c645825da031)

The zion-person-service thing is because we have 2 versions of it (8.0.0, and 8.1.1 where tree-groups has 8.1.1 and the rest has 8.0.0). The cjs instead of es is because a tsconfig is used. In our ts app, we also get cjs instead of es.

proof that ts app also uses cjs instead of es.
![image](https://github.com/fs-webdev/create-react-app/assets/77301861/597e2d56-94c8-4d43-8041-b3cd89ef2552)

The cjs and es difference should be inconsequential.