### PR TITLE
Reduce coalesceLocales noise

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/coalesceLocales.js
+++ b/packages/react-scripts/scripts/coalesceLocales.js
@@ -106,11 +106,11 @@ exports.coalesceLocales = paths => {
   }
   if (collisionReport.collisions.length > 0) {
     console.error(
-      `ERROR: There were ${collisionReport.collisions.length} collisions were detected when coalescing locales. To see a list of all collisions, turn on debugging with "DEBUG=coalesceLocales" before the command you just ran`
+      `ERROR: There were ${collisionReport.collisions.length} collisions were detected when coalescing locales.`
     );
     collisionReport.collisions.forEach(
       ({ key, locale, ns, newValue, oldValue }) =>
-        debug(
+        console.error(
           `\tkey=${key} namespace=${ns} locale=${locale} newValue="${newValue}" oldValue="${oldValue}"`
         )
     );

--- a/packages/react-scripts/scripts/coalesceLocales.js
+++ b/packages/react-scripts/scripts/coalesceLocales.js
@@ -106,12 +106,11 @@ exports.coalesceLocales = paths => {
   }
   if (collisionReport.collisions.length > 0) {
     console.error(
-      `ERROR: The following ${collisionReport.collisions.length} collisions were detected when coalescing locales:`,
-      collisionReport.collisions
+      `ERROR: There were ${collisionReport.collisions.length} collisions were detected when coalescing locales. To see a list of all collisions, turn on debugging with "DEBUG=coalesceLocales" before the command you just ran`
     );
     collisionReport.collisions.forEach(
       ({ key, locale, ns, newValue, oldValue }) =>
-        console.error(
+        debug(
           `\tkey=${key} namespace=${ns} locale=${locale} newValue="${newValue}" oldValue="${oldValue}"`
         )
     );


### PR DESCRIPTION
Remove clutter from normal logs by only showing the exact collisions when debugging rather  than always with console.error.

Instead of seeing something like this:
![image](https://github.com/fs-webdev/create-react-app/assets/77301861/d6c758d5-a804-496f-889a-422aa2433797)


We would see something like this:
![image](https://github.com/fs-webdev/create-react-app/assets/77301861/20212f5e-d369-4490-9b05-9af5def6a405)
