### PR TITLE
Release 8.5.3 - fix coalesceLocales to handle undefined paths better

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,7 @@
+## 8.5.3
+
+- Fix coalesceLocales to handle undefined paths better
+
 ## 8.5.2
 
 - Ignore eslint warnings during the `build` script

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.5.2",
+  "version": "8.5.3",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/coalesceLocales.js
+++ b/packages/react-scripts/scripts/coalesceLocales.js
@@ -60,6 +60,8 @@ exports.coalesceLocales = paths => {
     keys: new Set(),
   };
   realList.forEach(p => {
+    if (!p) return
+    
     const dir = path.dirname(p);
     // console.log('dir', dir)
     const locales = fs


### PR DESCRIPTION
When searching for locale files, some glob searches return undefined paths which end up breaking some of the logic. This fixes that by skipping undefined paths.

The Error that would show up:
```
The "path" argument must be of type string. Received undefined
```

This only happens when certain combinations of dependencies result in npm leaving those dependencies in node_modules under the parent instead of hoisting to the root.

After triaging the cause of the error and trying to avoid getting the undefined paths, that was trickier to get right as it depends on third party behavior, and it seemed easier to just allow the undefined paths through, but skip them once we try to inspect them.