### PR TITLE
Fix proxy to work with Russian test user

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,7 @@
+## 8.5.5
+
+- Fix proxy to work with Russian test user
+
 ## 8.5.4
 
 - Fix coalesceLocales to handle Windows/WSL paths correctly

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -30,7 +30,8 @@
     "template-typescript",
     "utils",
     "polyfills.js",
-    "per-locale-loader"
+    "per-locale-loader",
+    "!**/*.test.*"
   ],
   "bin": {
     "react-scripts": "./bin/react-scripts.js"

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.5.4",
+  "version": "8.5.5",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/proxy/getDataLocalizationRouter.js
+++ b/packages/react-scripts/proxy/getDataLocalizationRouter.js
@@ -1,0 +1,34 @@
+/**
+ * Gets a router function for http-proxy-middleware that
+ * checks the session in the auth header and modifies the target
+ * based on the session ruleSet for data localization cases
+ * (e.g. Russia: https://beta.familysearch.org -> https://beta-ru.familysearch.org).
+ */
+
+module.exports = ({ proxyConfig, target }) =>
+  function changeTargetBasedOnSessionRuleSet(req) {
+    // only return a target string from this function if the target needs changing
+    // otherwise the middleware logs an unnecessary "[HPM] Router new target:"
+    if (proxyConfig.options?.target) {
+      // Do not interfere with custom target
+      return
+    }
+    // Check session and change target based on ruleSet for data localization cases (e.g. Russia)
+    // WARNING: Do not directly parse the session in your app.
+    // We have to do it here for localhost development
+    // since the Lambda@Edge function will enforce a redirect which will end up dropping the auth header.
+    const auth = req.get('Authorization')
+    if (!auth) {
+      return
+    }
+    // https://fhconfluence.churchofjesuschrist.org/display/Product/Session+ID+Format
+    // example header value: "Bearer p0-Adeq12~_tmc.Qed~3_4ZuIY"
+    const ruleSet = /bearer\s+\w{1}(?<ruleSet>\d+)/i.exec(auth)?.groups?.ruleSet
+    let subdomainSuffix
+    if (ruleSet === '1') {
+      // Russian data localization
+      subdomainSuffix = '-ru'
+      console.log('Rewriting target for Russian data localization')
+    }
+    return subdomainSuffix && target.replace('.familysearch.org', `${subdomainSuffix}.familysearch.org`)
+  };

--- a/packages/react-scripts/proxy/getDataLocalizationRouter.test.js
+++ b/packages/react-scripts/proxy/getDataLocalizationRouter.test.js
@@ -1,0 +1,77 @@
+// eslint-disable-next-line strict
+const getDataLocalizationRouter = require("./getDataLocalizationRouter.js");
+
+const DEFAULT_TARGET = 'https://beta.familysearch.org'
+
+test('does not modify custom target', () => {
+  const proxyConfig = {
+    route: '/foo',
+    options: {
+      target: 'https://example.com'
+    }
+  }
+  const fn = getDataLocalizationRouter({ proxyConfig, target: DEFAULT_TARGET })
+  const newTarget = fn()
+  expect(newTarget).toBeUndefined()
+})
+
+test('does not modify target if no auth', () => {
+  const proxyConfig = {
+    route: '/foo',
+  }
+  const req = { get: () => undefined }
+  const fn = getDataLocalizationRouter({ proxyConfig, target: DEFAULT_TARGET })
+  const newTarget = fn(req)
+  expect(newTarget).toBeUndefined()
+})
+
+test('does not modify target for regular session', () => {
+  const proxyConfig = {
+    route: '/foo',
+  }
+  const req = { get: () => 'Bearer b0-87987987' }
+  const fn = getDataLocalizationRouter({ proxyConfig, target: DEFAULT_TARGET })
+  const newTarget = fn(req)
+  expect(newTarget).toBeUndefined()
+})
+
+test('does not modify target for session missing rule set', () => {
+  const proxyConfig = {
+    route: '/foo',
+  }
+  const req = { get: () => 'Bearer b-87987987' }
+  const fn = getDataLocalizationRouter({ proxyConfig, target: DEFAULT_TARGET })
+  const newTarget = fn(req)
+  expect(newTarget).toBeUndefined()
+})
+
+test('rewrites target for Russian session (beta)', () => {
+  const proxyConfig = {
+    route: '/foo',
+  }
+  const req = { get: () => 'bearer b1-87987987' }
+  const fn = getDataLocalizationRouter({ proxyConfig, target: DEFAULT_TARGET })
+  const newTarget = fn(req)
+  expect(newTarget).toEqual('https://beta-ru.familysearch.org')
+})
+
+test('rewrites target for Russian session (integration)', () => {
+  const proxyConfig = {
+    route: '/foo',
+  }
+  const req = { get: () => 'Bearer i1-87987987' }
+  const fn = getDataLocalizationRouter({ proxyConfig, target: 'https://integration.familysearch.org' })
+  const newTarget = fn(req)
+  expect(newTarget).toEqual('https://integration-ru.familysearch.org')
+})
+
+test('rewrites target for Russian session (production)', () => {
+  const proxyConfig = {
+    route: '/foo',
+  }
+  const req = { get: () => 'Bearer p1-87987987' }
+  const fn = getDataLocalizationRouter({ proxyConfig, target: 'https://www.familysearch.org' })
+  const newTarget = fn(req)
+  expect(newTarget).toEqual('https://www-ru.familysearch.org')
+})
+

--- a/packages/react-scripts/proxy/setupProxy.js
+++ b/packages/react-scripts/proxy/setupProxy.js
@@ -14,6 +14,7 @@ const setProxies = (app, customProxies = []) => {
   const auth = require('@fs/auth-middleware')
   const resolver = require('./resolver')
   const proxyList = require('./proxies')
+  const getDataLocalizationRouter = require('./getDataLocalizationRouter')
 
   // middleware required for auth middleware
   app.use(metric())
@@ -35,6 +36,7 @@ const setProxies = (app, customProxies = []) => {
       changeOrigin: true,
       logLevel: 'debug',
       timeout: 5000,
+      router: getDataLocalizationRouter({ proxyConfig, target }),
       ...proxyConfig.options,
     }
 


### PR DESCRIPTION
Fix proxy to work with Russian test user.

Add router function to proxy config to work with Russian data localization.

When target changes logging looks like this:

<img width="995" alt="image" src="https://github.com/fs-webdev/create-react-app/assets/2666679/d9ccc4e0-12dd-48a8-8a9e-b284ea30f104">

If the unit tests aren't wanted, I can remove them. They helped me make sure I covered all the cases but it didn't seem like the package was setup to handle them. I ran them directly inside the folder with `npx jest ./getDataLocalizationRouter.test.js`.


See https://familysearch.slack.com/archives/C06FR9QDBRB/p1716312966290559 and https://fhjira.churchofjesuschrist.org/browse/RUSSIA-463 for background.

