### PR TITLE
Fix frontierMaster build: remove edge travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,26 +33,22 @@ script:
 before_deploy: "cd ${TRAVIS_BUILD_DIR}/packages/react-scripts"
 deploy:
   - provider: script
-    edge: true
     cleanup: false
     script: npm run fs-publish -- --allow-earlier-version
     on:
       branch: frontierMaster
   - provider: script
-    edge: true
     cleanup: false
     script: npm run fs-publish -- --allow-earlier-version
     on:
       branch: v7.x
   - provider: script
-    edge: true
     cleanup: false
     script: npm run fs-publish -- --allow-earlier-version
     on:
       branch: next
   - provider: script
     skip_cleanup: true
-    edge: true
     cleanup: false
     script: cd ${TRAVIS_BUILD_DIR} && ./freshCraTemplateUpdate.sh
     on:


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->


Fix frontierMaster build: remove edge travis.

This should hopefully clear up the Ruby error we have been seeing in the frontierMaster build for a few weeks.

Here is the error:
```
0.00s$ cd ${TRAVIS_BUILD_DIR}/packages/react-scripts
$ rvm $(travis_internal_ruby) --fuzzy do ruby -S gem uninstall -aIx dpl
Gem 'dpl' is not installed
33.08s$ rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl --pre
ERROR:  Error installing dpl:
	The last version of dpl (>= 0) to support your Ruby & RubyGems was 2.0.3.beta.4. Try installing it with `gem install dpl -v 2.0.3.beta.4`
	dpl requires Ruby version >= 3. The current ruby version is 2.7.6.219.
Successfully installed mime-0.4.4
Successfully installed json_pure-2.7.2
Successfully installed excon-0.110.0
Successfully installed travis-packagecloud-ruby-1.1.0
Successfully installed regstry-1.0.15
Successfully installed travis-cl-1.2.4
The command "rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl --pre" failed and exited with 1 during .
```


Removing edge seems to work after some experiments on a different branch. Another potential solution could involve setting a `dpl_version`.






