### PR TITLE
Fix travis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,23 +33,30 @@ script:
 before_deploy: "cd ${TRAVIS_BUILD_DIR}/packages/react-scripts"
 deploy:
   - provider: script
+    edge: true
     cleanup: false
+    dpl_version: 2.0.3.beta.4
     script: npm run fs-publish -- --allow-earlier-version
     on:
       branch: frontierMaster
   - provider: script
+    edge: true
     cleanup: false
+    dpl_version: 2.0.3.beta.4
     script: npm run fs-publish -- --allow-earlier-version
     on:
       branch: v7.x
   - provider: script
+    edge: true
     cleanup: false
+    dpl_version: 2.0.3.beta.4
     script: npm run fs-publish -- --allow-earlier-version
     on:
       branch: next
   - provider: script
-    skip_cleanup: true
+    edge: true
     cleanup: false
+    dpl_version: 2.0.3.beta.4
     script: cd ${TRAVIS_BUILD_DIR} && ./freshCraTemplateUpdate.sh
     on:
       branch: frontierMaster


### PR DESCRIPTION
Fix travis publish by switching back to edge and pinning dpl_version. This seems to work.

Alternatively, you can remove edge and then use `skip_cleanup: true`.

The advantage with edge is we won't be on a deprecated dpl version.


Note, the "View config" in the Travis build will show a warning for using the dpl_version key but it is in fact a valid key that is used.


Here is a the passing build that I setup with a test branch that shows that this should work https://app.travis-ci.com/github/fs-webdev/create-react-app/builds/270820353 .