### PR TITLE
Cypress Support for Apps

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,8 @@
+## 8.7.0
+
+- Provide a simpleCoalesceLocales and simple-webpack.config.js files for use by cypress in apps. This speeds things up compared to using the
+  regular versions of those files.
+
 ## 8.6.0
 
 - Add some logic in webpack.config.js to look for CRA_MAGIC_ZION_UI_VERSION and CRA_MAGIC_REACT_SCRIPTS_VERSION and calculate

--- a/package-lock.json
+++ b/package-lock.json
@@ -16223,6 +16223,110 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/css-hot-loader": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/css-hot-loader/-/css-hot-loader-1.4.4.tgz",
+      "integrity": "sha512-J/qXHz+r7FOT92qMIJfxUk0LC9fecQNZVr0MswQ4FOpKLyOCBjofVMfc6R268bh/5ktkTShrweMr0wWqerC92g==",
+      "license": "ISC",
+      "dependencies": {
+        "loader-utils": "^1.1.0",
+        "lodash": "^4.17.5",
+        "normalize-url": "^1.9.1"
+      }
+    },
+    "node_modules/css-hot-loader/node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-hot-loader/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/css-hot-loader/node_modules/loader-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/css-hot-loader/node_modules/normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha512-A48My/mtCklowHBlI8Fq2jFWK4tX4lJ5E6ytFsSOq1fzpvT0SQSgKhSg7lN5c2uYFOrUAOQp6zhhJnpp1eMloQ==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-hot-loader/node_modules/prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-hot-loader/node_modules/query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha512-O2XLNDBIg1DnTOa+2XrIwSiXEV8h2KImXUnjhhn2+UsvZ+Es2uyd5CCRTNQlDGbzUQOW3aYCBx9rVA6dzsiY7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-hot-loader/node_modules/sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-hot-loader/node_modules/strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/css-loader": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.11.0.tgz",
@@ -44295,7 +44399,7 @@
     },
     "packages/react-scripts": {
       "name": "@fs/react-scripts",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -44318,6 +44422,7 @@
         "cookie-parser": "^1.4.4",
         "copy-webpack-plugin": "^4.6.0",
         "core-js": "^3.6.4",
+        "css-hot-loader": "^1.4.4",
         "css-loader": "^6.5.1",
         "css-minimizer-webpack-plugin": "^3.2.0",
         "debug": "^4.3.4",

--- a/packages/react-scripts/config/simple-webpack.config.js
+++ b/packages/react-scripts/config/simple-webpack.config.js
@@ -1,0 +1,122 @@
+'use strict'
+const path = require('path')
+const webpack = require('webpack')
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const babelConfig = require.resolve('@fs/babel-preset-frontier')
+
+const d3DagRegex = /[\\/]node_modules[\\/]d3-dag/
+
+module.exports = {
+  mode: 'development',
+  devtool: false,
+  resolve: {
+    alias: {
+      'react-native': 'react-native-web',
+      // just get the dirname here because @react-google-maps/api is importing "react/jsx-runtime", so we can't just use require.resolve
+      react: path.dirname(require.resolve('react')),
+      'react-dom': require.resolve('react-dom'),
+      i18next: require.resolve('i18next'),
+      'react-i18next': require.resolve('react-i18next'),
+      'react-router': require.resolve('react-router'),
+      // '@material-ui/styles': require.resolve('@material-ui/styles'),
+      '/coalesced-locales': path.resolve(path.join(process.cwd(), 'dist/locales/')),
+    },
+    extensions: ['.ts', '.tsx', '.jsx', '.js', '.json'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              plugins: babelConfig.plugins,
+            },
+          },
+        ],
+        include: (input) => input.match(d3DagRegex),
+      },
+      {
+        test: /\.(mjs|tsx?|jsx?)$/,
+        exclude: /(node_modules|dist)/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              plugins: [
+                [
+                  'istanbul',
+                  {
+                    exclude: ['cypress/**/*.*', 'src/locales/**/*.*', 'src/**/fixtures/*.js'],
+                  },
+                ],
+                '@babel/plugin-proposal-optional-chaining',
+                '@babel/plugin-proposal-nullish-coalescing-operator',
+                'babel-plugin-macros',
+                [
+                  '@babel/plugin-proposal-class-properties',
+                  {
+                    loose: true,
+                  },
+                ],
+                [
+                  '@babel/plugin-proposal-private-methods',
+                  {
+                    loose: true,
+                  },
+                ],
+                [
+                  '@babel/plugin-proposal-private-property-in-object',
+                  {
+                    loose: true,
+                  },
+                ],
+              ],
+              presets: ['@babel/preset-react'],
+              ignore: ['**/dist/*'],
+              babelrc: false,
+            },
+          },
+        ],
+      },
+      {
+        test: /\.mdx?$/,
+        loader: 'ignore-loader',
+      },
+      {
+        test: /\.(svg|ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\?.*)?$/,
+        loader: require.resolve('file-loader'),
+        options: {
+          esModule: false,
+          name: 'static/media/[path][name].[ext]',
+        },
+      },
+      {
+        test: /\.(mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,
+        loader: require.resolve('url-loader'),
+        options: {
+          limit: 10000,
+          name: 'static/media/[path][name].[ext]',
+        },
+      },
+      {
+        test: /\.css$/,
+        use: [
+          'css-hot-loader',
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            options: { sourceMap: true },
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new MiniCssExtractPlugin({ filename: 'styles.css', ignoreOrder: true }),
+    new webpack.ProvidePlugin({
+      React: 'react',
+    }),
+  ],
+}

--- a/packages/react-scripts/config/simple-webpack.config.js
+++ b/packages/react-scripts/config/simple-webpack.config.js
@@ -1,3 +1,6 @@
+/*
+ * This file is used specifically for cypress setup/configuration.
+ */
 'use strict'
 const path = require('path')
 const webpack = require('webpack')

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.6.0",
+  "version": "8.7.0",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {
@@ -68,6 +68,7 @@
     "cookie-parser": "^1.4.4",
     "copy-webpack-plugin": "^4.6.0",
     "core-js": "^3.6.4",
+    "css-hot-loader": "^1.4.4",
     "css-loader": "^6.5.1",
     "css-minimizer-webpack-plugin": "^3.2.0",
     "debug": "^4.3.4",
@@ -134,9 +135,9 @@
     "fsevents": "^2.3.2"
   },
   "peerDependencies": {
+    "@fs/eslint-config-frontier-react": ">=10.0.0",
     "react": ">= 16",
-    "typescript": "^3.2.1 || ^4 || ^5",
-    "@fs/eslint-config-frontier-react": ">=10.0.0"
+    "typescript": "^3.2.1 || ^4 || ^5"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/react-scripts/scripts/simpleCoalesceLocales.js
+++ b/packages/react-scripts/scripts/simpleCoalesceLocales.js
@@ -1,3 +1,7 @@
+/**
+ * This file is used specifically for cypress setup/configuration.
+ */
+
 'use strict'
 const jsonfile = require('jsonfile')
 const path = require('path')

--- a/packages/react-scripts/scripts/simpleCoalesceLocales.js
+++ b/packages/react-scripts/scripts/simpleCoalesceLocales.js
@@ -1,0 +1,45 @@
+'use strict'
+const jsonfile = require('jsonfile')
+const path = require('path')
+const fs = require('fs-extra')
+const glob = require('fast-glob')
+const debug = require('debug')('locales:coalesce')
+
+module.exports = () => {
+  console.time('per-locale coalesce')
+  const cwd = process.cwd()
+  const builtLocalesDir = `${cwd}/dist/locales/dist`
+  fs.ensureDirSync(builtLocalesDir, { recursive: true })
+
+  const files = glob.sync([
+    'node_modules/@fs/zion-*/dist/es/locales/index.js',
+    'node_modules/@fs/tree-*/dist/es/locales/index.js',
+  ])
+
+  const allLocales = {}
+  files.forEach((p) => {
+    const dir = path.dirname(p)
+    const locales = fs.readdirSync(dir).filter((d) => !d.includes('.'))
+    debug('files foreach', p, dir, locales)
+    locales.forEach((locale) => {
+      const namespaces = fs.readdirSync(path.join(dir, locale)).map((d) => d.split('.')[0])
+      allLocales[locale] = allLocales[locale] || {}
+      namespaces.forEach((ns) => {
+        const strings = jsonfile.readFileSync(`${path.join(dir, locale, ns)}.json`)
+        allLocales[locale][ns] = allLocales[locale][ns] || {}
+        allLocales[locale][ns] = { ...allLocales[locale][ns], ...strings }
+      })
+    })
+  })
+
+  Object.keys(allLocales).forEach((locale) => {
+    fs.ensureDirSync(path.join(builtLocalesDir, locale))
+    Object.keys(allLocales[locale]).forEach((namespace) => {
+      debug('write json', `${path.join(builtLocalesDir, locale, namespace)}.json`)
+      jsonfile.writeFileSync(`${path.join(builtLocalesDir, locale, namespace)}.json`, allLocales[locale][namespace])
+    })
+  })
+
+  console.timeEnd('per-locale coalesce')
+  debug('allLocales', allLocales)
+}


### PR DESCRIPTION
* Add simple webpack config 
  * While the normal `webpack.config.js` works for cypress, it takes about 30 seconds longer on initial compile and several seconds between saves on my new M3. This simple webpack config is almost instant for both. I thought this would be a good place to keep it
* Add simple coalesce locales function
  * This is also for performance. Depending on the app, it can take several seconds to build the dependency graph and complete the real coalesceLocales. This is the same function we use in zion for storybook and cypress component tests.
