### PR TITLE
include app's locales

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/simpleCoalesceLocales.js
+++ b/packages/react-scripts/scripts/simpleCoalesceLocales.js
@@ -16,6 +16,7 @@ module.exports = () => {
   fs.ensureDirSync(builtLocalesDir, { recursive: true })
 
   const files = glob.sync([
+    `${cwd}/src/locales/index.js`,
     'node_modules/@fs/zion-*/dist/es/locales/index.js',
     'node_modules/@fs/tree-*/dist/es/locales/index.js',
   ])
@@ -23,7 +24,7 @@ module.exports = () => {
   const allLocales = {}
   files.forEach((p) => {
     const dir = path.dirname(p)
-    const locales = fs.readdirSync(dir).filter((d) => !d.includes('.'))
+    const locales = fs.readdirSync(dir).filter((d) => !d.includes('.') && !d.includes('dist'))
     debug('files foreach', p, dir, locales)
     locales.forEach((locale) => {
       const namespaces = fs.readdirSync(path.join(dir, locale)).map((d) => d.split('.')[0])


### PR DESCRIPTION
The pilot-dashboard app where I copied this from didn't have any app locales, so it just pulled them in from node_modules. This change includes the app's locales as well now.