### PR TITLE
Fix fr-test script

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.7.2",
+  "version": "8.7.3",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/fr-test.js
+++ b/packages/react-scripts/scripts/fr-test.js
@@ -25,7 +25,8 @@ const mergeReports = ()=>{
 // dev ran npm test
 if(!process.env.CI){
   const args = process.argv.slice(2).join(' ')
-  return execSync(`react-scripts test ${args}`)
+  execSync(`react-scripts test ${args}`, { stdio: 'inherit' })
+  return
 }
 
 // reset


### PR DESCRIPTION
## Issue
`npm test` wasn't using the same `stdio` as the parent, so it didn't bring up the jest ui to run tests.