### PR TITLE
Add retry chunk load for simple webpack

### DIFF
--- a/packages/react-scripts/config/simple-webpack.config.js
+++ b/packages/react-scripts/config/simple-webpack.config.js
@@ -6,6 +6,7 @@ const path = require('path')
 const webpack = require('webpack')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const babelConfig = require.resolve('@fs/babel-preset-frontier')
+const { RetryChunkLoadPlugin } = require('webpack-retry-chunk-load-plugin')
 
 const d3DagRegex = /[\\/]node_modules[\\/]d3-dag/
 
@@ -120,6 +121,16 @@ module.exports = {
     new MiniCssExtractPlugin({ filename: 'styles.css', ignoreOrder: true }),
     new webpack.ProvidePlugin({
       React: 'react',
+    }),
+    new RetryChunkLoadPlugin({
+      // optional stringified function to get the cache busting query string appended to the script src
+      // if not set will default to appending the string `?cache-bust=true`
+      cacheBust: `function() { return Date.now() }`,
+      // optional value to set the maximum number of retries to load the chunk. Default is 1
+      maxRetries: 5,
+      // optional code to be executed in the browser context if after all retries chunk is not loaded.
+      // if not set - nothing will happen and error will be returned to the chunk loader.
+      // lastResortScript: "window.location.href='/500.html'"
     }),
   ],
 }

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.7.4",
+  "version": "8.7.5",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
I was seeing issues with the cypress tests in group-mangaement, which uses the simple webpack config. @tylergraf suggested using the retry chunk load plugin. I looked at how it was used in the normal webpack config and added it to the simple webpack config accordingly. I tested this change in group-management and it seems to work. See https://github.com/fs-webdev/group-management/pull/635 where the travis build passes. (I used [gitpkg ](https://gitpkg.vercel.app/) to make it possible to install the package right from github from the subfolder)

The issues we were getting in travis without this fix:
![image](https://github.com/user-attachments/assets/df6d7cc8-430d-49a5-93b0-8624d87fc0ba)
![image](https://github.com/user-attachments/assets/21a98bef-24c3-41d5-9879-a6876563fcf7)
