### PR TITLE
Update feature check config/tests for breaking features

### DIFF
--- a/packages/react-scripts/layout/views/partials/featureDetection.ejs
+++ b/packages/react-scripts/layout/views/partials/featureDetection.ejs
@@ -1,5 +1,28 @@
 if (Modernizr) {
   const unsupportedBrowserHeader = document.getElementById('unsupported-browser');
+
+  Modernizr.addTest('replaceAll', () => {
+      return typeof String.prototype.replaceAll === 'function';
+  });
+
+  Modernizr.addTest('privateFields', () => {
+    try {
+        class Test {
+            #privateField = 42;
+            getPrivateField() {
+                return this.#privateField;
+            }
+        }
+
+        const instance = new Test();
+        return instance.getPrivateField() === 42;
+    } catch (e) {
+        return false;
+    }
+  });
+
+  console.log(Modernizr);
+
   const outdatedFeatures = Object.keys(Modernizr).filter(feature => !Modernizr[feature]);
 
   if (unsupportedBrowserHeader) {

--- a/packages/react-scripts/layout/views/partials/featureDetection.ejs
+++ b/packages/react-scripts/layout/views/partials/featureDetection.ejs
@@ -21,8 +21,6 @@ if (Modernizr) {
     }
   });
 
-  console.log(Modernizr);
-
   const outdatedFeatures = Object.keys(Modernizr).filter(feature => !Modernizr[feature]);
 
   if (unsupportedBrowserHeader) {

--- a/packages/react-scripts/modernizr-config.json
+++ b/packages/react-scripts/modernizr-config.json
@@ -1,5 +1,8 @@
 {
     "minify": true,
+    "options": [
+      "addTest"
+    ],
     "feature-detects": [
       "test/customevent",
       "test/dom/intersection-observer",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Updated the Modernizr config to feature check some JS features that break the site. These JS features aren't natively available in Modernizer, so custom tests were built out to provide the checks. 

It was found that:
- Chrome/Edge v84
  - threw a replaceAll error: https://caniuse.com/mdn-javascript_builtins_string_replaceall 
- Firefox 89 & Safari 14
  - threw a private class error: https://caniuse.com/mdn-javascript_classes_private_class_fields 

are versions that currently break (we couldn't even get versions as old as the previous feature checks required). 
