### PR TITLE
prevent private field feature check from just erroring out

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,7 @@
+## 8.7.10
+
+- Feature detection for private class fields was erroring out before running the check, now it will be within `eval` so it will run even if the browser doesn't support it.
+
 ## 8.7.9
 
 - Add additional check for unsupported browser banner to avoid errors

--- a/packages/react-scripts/layout/views/partials/featureDetection.ejs
+++ b/packages/react-scripts/layout/views/partials/featureDetection.ejs
@@ -7,18 +7,11 @@ if (Modernizr) {
 
   Modernizr.addTest('privateFields', () => {
     try {
-        class Test {
-            #privateField = 42;
-            getPrivateField() {
-                return this.#privateField;
-            }
-        }
-
-        const instance = new Test();
-        return instance.getPrivateField() === 42;
-    } catch (e) {
-        return false;
-    }
+    eval("class Test { #privateField; }");
+    return true;
+  } catch (e) {
+    return false;
+  }
   });
 
   const outdatedFeatures = Object.keys(Modernizr).filter(feature => !Modernizr[feature]);

--- a/packages/react-scripts/layout/views/partials/featureDetection.ejs
+++ b/packages/react-scripts/layout/views/partials/featureDetection.ejs
@@ -7,11 +7,11 @@ if (Modernizr) {
 
   Modernizr.addTest('privateFields', () => {
     try {
-    eval("class Test { #privateField; }");
-    return true;
-  } catch (e) {
-    return false;
-  }
+      eval("class Test { #privateField; }");
+      return true;
+    } catch (e) {
+      return false;
+    }
   });
 
   const outdatedFeatures = Object.keys(Modernizr).filter(feature => !Modernizr[feature]);

--- a/packages/react-scripts/layout/views/partials/featureDetection.ejs
+++ b/packages/react-scripts/layout/views/partials/featureDetection.ejs
@@ -1,10 +1,13 @@
 if (Modernizr) {
   const unsupportedBrowserHeader = document.getElementById('unsupported-browser');
 
+  <%# Handles Chrome/Edge v84 and lower %>
   Modernizr.addTest('replaceAll', () => {
       return typeof String.prototype.replaceAll === 'function';
   });
 
+  <%# Handles Firefox v90/Safari v15 and lower %>
+  <%# Written with eval because declaring a function with private class fields threw an error outside of the catch %>
   Modernizr.addTest('privateFields', () => {
     try {
       eval("class Test { #privateField; }");
@@ -14,10 +17,8 @@ if (Modernizr) {
     }
   });
 
-  const outdatedFeatures = Object.keys(Modernizr).filter(feature => !Modernizr[feature]);
-
   if (unsupportedBrowserHeader) {
-    if (outdatedFeatures.length > 0) {
+    if (Object.keys(Modernizr).filter(feature => !Modernizr[feature]).length > 0) {
       unsupportedBrowserHeader.style.display = 'block';
     } else {
       unsupportedBrowserHeader.remove();

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.7.9",
+  "version": "8.7.10",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

The class private field feature check was blowing up before it was being added as a test in modernizr. This is to allow it to all be defined and then eval'd by the browser. 

Note: I haven't been able to test this as we don't have access to a browser old enough and able to run `eval`