### PR TITLE
use browser-resolve for splitio imports in jest config

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,7 @@
+## 8.7.10
+
+- Have jest configuration use browser-resolve for requires in splitio packages. Only affects jest tests, nothing else.
+
 ## 8.7.9
 
 - Add additional check for unsupported browser banner to avoid errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -12273,6 +12273,14 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/browser-resolve": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+      "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
+      "dependencies": {
+        "resolve": "^1.17.0"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.23.3",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
@@ -41164,7 +41172,7 @@
     },
     "packages/react-scripts": {
       "name": "@fs/react-scripts",
-      "version": "8.7.8",
+      "version": "8.7.9",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -41178,6 +41186,7 @@
         "babel-plugin-bundled-import-meta": "^0.3.2",
         "babel-plugin-named-asset-import": "^0.3.8",
         "bfj": "^7.0.2",
+        "browser-resolve": "^2.0.0",
         "browserslist": "^4.18.1",
         "camelcase": "^6.2.1",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.7.9",
+  "version": "8.7.10",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -60,6 +60,7 @@
     "babel-plugin-bundled-import-meta": "^0.3.2",
     "babel-plugin-named-asset-import": "^0.3.8",
     "bfj": "^7.0.2",
+    "browser-resolve": "^2.0.0",
     "browserslist": "^4.18.1",
     "camelcase": "^6.2.1",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -25,6 +25,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
 
   const config = {
     roots: ['<rootDir>/src'],
+    resolver: `${__dirname}/jestResolver.js`,
 
     collectCoverageFrom:[
       "src/**/*.{js,jsx,ts,tsx}",

--- a/packages/react-scripts/scripts/utils/jestResolver.js
+++ b/packages/react-scripts/scripts/utils/jestResolver.js
@@ -1,0 +1,9 @@
+'use strict'
+const browserResolve = require('browser-resolve')
+
+module.exports = (path, options) => {
+  if (options.basedir.includes('@splitsoftware/splitio')) {
+    return browserResolve.sync(path, options)
+  }
+  return options.defaultResolver(path, options)
+}


### PR DESCRIPTION
Jest has an issue consuming split. The way they bundle things makes jest use the "main" version, and not the "browser" version of code from their package.json files. Split suggest using the jest config `browser: true`, but that is deprecated in jest and doesn't work anymore. 
https://help.split.io/hc/en-us/articles/360034151511-Javascript-SDK-Error-Shared-Client-not-supported-by-the-storage-mechanism-Create-isolated-instances-instead

Jest suggests using a custom resolver for tweaking things. https://jestjs.io/docs/configuration#resolver-string

We I decided to do is check for if we're doing a `require` in a splitio directory, if so, then use the browser-resolve package, otherwise use the default jest resolver.

So this should have a pretty minimal area of effect.

The detailed issue is that while jest is resolving files, @splitsoftware/splitio/package.json main points to a file, and that file requires in './factory'. 'factory' is actually a directory with a package.json file with the following.
```javascript
{
  "main": "./node.js",
  "browser": "./browser.js"
}
```

Jest SHOULD be using the browser field since we're using jest-environment-jsdom, but it doesn't, it keeps using `main` which points to 'node.js', which is not allowed in a jest browser environment. 

I tried a few different things to fix it, but the browser-resolve was the only thing that worked.

We don't see this issue in zion, because we mock flags-js, so we never get through to the @splitsoftware/splitio requiring.