### PR TITLE
Remove ident from proxies

### DIFF
--- a/packages/react-scripts/proxy/proxies.js
+++ b/packages/react-scripts/proxy/proxies.js
@@ -44,9 +44,6 @@ const proxies = [
     route: '/home/banner',
   },
   {
-    route: '/ident',
-  },
-  {
     route: '/mobile',
   },
   {


### PR DESCRIPTION
Identity team is trying to use dtmulator in our apps but since many of our apps have binding_sets such as `recovery.identity`, by default the requests for our pages are being proxied to the integration app because of the `/ident/` proxy entry. Removing the `ident` proxy entry will resolve this issue.

There still are some usages of this for entering/existing helper mode. We could probably work with those teams to add a proxy entry for those limited cases.


Just brainstorming, here are some alternatives:

- Remove the `/ident` proxy--search GitHub usage and notify those impacted so they can create a proxy rule
- Provide/figure out a way to opt out of the `/ident` proxy that Identity team can use or Identity team can work around it with something like `require('@fs/react-scripts/proxy/proxies').find(({ route }) => route === '/ident').route = '/ident-no-proxy'` in their setupProxy file