### PR TITLE
Add flag to disable SERVER_DATA.isLoggedIn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41170,7 +41170,7 @@
     },
     "packages/react-scripts": {
       "name": "@fs/react-scripts",
-      "version": "8.8.0",
+      "version": "8.8.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -46,7 +46,7 @@
       SERVER_DATA.sgBaseUrl = "<%= process.env.SG_BASE_URL %>"
       SERVER_DATA.splitioAuthKey = "<%= process.env.SPLITIO_AUTH_KEY %>"
       SERVER_DATA.geoData = <%- typeof geoData !== 'undefined' ? JSON.stringify(geoData) : JSON.stringify({}) %>;
-      <% if (!getFeatureFlag('frontier_server_removeIsLoggedIn', { appName }).isOn) { %>
+      <% if (typeof skipSessionPrevalidation != 'undefined' && !skipSessionPrevalidation) { %>
         SERVER_DATA.isLoggedIn = <%= isLoggedIn %>
       <% } %>
       <% include partials/experiments %>

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -46,7 +46,6 @@
       SERVER_DATA.sgBaseUrl = "<%= process.env.SG_BASE_URL %>"
       SERVER_DATA.splitioAuthKey = "<%= process.env.SPLITIO_AUTH_KEY %>"
       SERVER_DATA.geoData = <%- typeof geoData !== 'undefined' ? JSON.stringify(geoData) : JSON.stringify({}) %>;
-      SERVER_DATA.isLoggedIn = <%= isLoggedIn %>
       <% include partials/experiments %>
       <% include partials/sentry %>
       <% include partials/clientAppConfig %>
@@ -55,6 +54,10 @@
         if (!window.dtinfo) window.dtinfo = {}
         window.dtinfo.appName = SERVER_DATA.appName
       }
+      // Apps that cache SERVER_DATA need this flag on.
+      <% if (!getFeatureFlag('frontier_server_removeIsLoggedIn', { appName: SERVER_DATA.appName }).isOn) { %>
+        SERVER_DATA.isLoggedIn = <%= isLoggedIn %>
+      <% } %>
     </script>
   </head>
   <body>

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -46,7 +46,7 @@
       SERVER_DATA.sgBaseUrl = "<%= process.env.SG_BASE_URL %>"
       SERVER_DATA.splitioAuthKey = "<%= process.env.SPLITIO_AUTH_KEY %>"
       SERVER_DATA.geoData = <%- typeof geoData !== 'undefined' ? JSON.stringify(geoData) : JSON.stringify({}) %>;
-      <% if (typeof skipSessionPrevalidation != 'undefined' && !skipSessionPrevalidation) { %>
+      <% if (typeof skipSessionPrevalidation !== 'undefined' && !skipSessionPrevalidation) { %>
         SERVER_DATA.isLoggedIn = <%= isLoggedIn %>
       <% } %>
       <% include partials/experiments %>

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -46,7 +46,7 @@
       SERVER_DATA.sgBaseUrl = "<%= process.env.SG_BASE_URL %>"
       SERVER_DATA.splitioAuthKey = "<%= process.env.SPLITIO_AUTH_KEY %>"
       SERVER_DATA.geoData = <%- typeof geoData !== 'undefined' ? JSON.stringify(geoData) : JSON.stringify({}) %>;
-      <% if (!getFeatureFlag('frontier_server_removeIsLoggedIn', { appName: process.env.APP_NAME }).isOn) { %>
+      <% if (!getFeatureFlag('frontier_server_removeIsLoggedIn', { appName }).isOn) { %>
         SERVER_DATA.isLoggedIn = <%= isLoggedIn %>
       <% } %>
       <% include partials/experiments %>

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -46,6 +46,9 @@
       SERVER_DATA.sgBaseUrl = "<%= process.env.SG_BASE_URL %>"
       SERVER_DATA.splitioAuthKey = "<%= process.env.SPLITIO_AUTH_KEY %>"
       SERVER_DATA.geoData = <%- typeof geoData !== 'undefined' ? JSON.stringify(geoData) : JSON.stringify({}) %>;
+      <% if (!getFeatureFlag('frontier_server_removeIsLoggedIn', { appName }).isOn) { %>
+        SERVER_DATA.isLoggedIn = <%= isLoggedIn %>
+      <% } %>
       <% include partials/experiments %>
       <% include partials/sentry %>
       <% include partials/clientAppConfig %>
@@ -54,10 +57,6 @@
         if (!window.dtinfo) window.dtinfo = {}
         window.dtinfo.appName = SERVER_DATA.appName
       }
-      // Apps that cache SERVER_DATA need this flag on.
-      <% if (!getFeatureFlag('frontier_server_removeIsLoggedIn', { appName: SERVER_DATA.appName }).isOn) { %>
-        SERVER_DATA.isLoggedIn = <%= isLoggedIn %>
-      <% } %>
     </script>
   </head>
   <body>

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -46,7 +46,7 @@
       SERVER_DATA.sgBaseUrl = "<%= process.env.SG_BASE_URL %>"
       SERVER_DATA.splitioAuthKey = "<%= process.env.SPLITIO_AUTH_KEY %>"
       SERVER_DATA.geoData = <%- typeof geoData !== 'undefined' ? JSON.stringify(geoData) : JSON.stringify({}) %>;
-      <% if (!getFeatureFlag('frontier_server_removeIsLoggedIn', { appName }).isOn) { %>
+      <% if (!getFeatureFlag('frontier_server_removeIsLoggedIn', { appName: process.env.APP_NAME }).isOn) { %>
         SERVER_DATA.isLoggedIn = <%= isLoggedIn %>
       <% } %>
       <% include partials/experiments %>

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.8.1",
+  "version": "8.8.2",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
Allow apps to remove SERVER_DATA.isloggedIn
This is to help apps that cache SERVER_DATA.

Comes after this pr https://github.com/fs-webdev/snow/pull/387
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

