### PR TITLE
[Cypress] ignore .map files in node_modules for cypress webpack.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21762,6 +21762,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/ignore-loader": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ignore-loader/-/ignore-loader-0.1.2.tgz",
+      "integrity": "sha512-yOJQEKrNwoYqrWLS4DcnzM7SEQhRKis5mB+LdKKh4cPmGYlLPR0ozRzHV5jmEk2IxptqJNQA5Cc0gw8Fj12bXA=="
+    },
     "node_modules/ignore-walk": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
@@ -41170,7 +41175,7 @@
     },
     "packages/react-scripts": {
       "name": "@fs/react-scripts",
-      "version": "8.8.2",
+      "version": "8.8.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -41208,6 +41213,7 @@
         "html-webpack-plugin": "^5.5.0",
         "http-proxy-middleware": "^3.0.2",
         "identity-obj-proxy": "^3.0.0",
+        "ignore-loader": "^0.1.2",
         "intersection-observer": "^0.12.0",
         "jest": "^27.4.3",
         "jest-resolve": "^27.4.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "docusaurus/website"
   ],
   "scripts": {
-    "build": "NODE_OPTIONS=\"--max-old-space-size=4096\" cd packages/react-scripts && node bin/react-scripts.js build",
+    "build": "cd packages/react-scripts && node bin/react-scripts.js build",
     "changelog": "lerna-changelog",
     "create-react-app": "node tasks/cra.js",
     "e2e": "tasks/e2e-simple.sh",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "docusaurus/website"
   ],
   "scripts": {
-    "build": "cd packages/react-scripts && node bin/react-scripts.js build",
+    "build": "NODE_OPTIONS=\"--max-old-space-size=4096\" cd packages/react-scripts && node bin/react-scripts.js build",
     "changelog": "lerna-changelog",
     "create-react-app": "node tasks/cra.js",
     "e2e": "tasks/e2e-simple.sh",

--- a/packages/react-scripts/config/simple-webpack.config.js
+++ b/packages/react-scripts/config/simple-webpack.config.js
@@ -1,5 +1,5 @@
 /*
- * This file is used specifically for cypress setup/configuration.
+ * This file is used specifically for cypress setup/configuration in apps.
  */
 'use strict'
 const path = require('path')
@@ -85,7 +85,7 @@ module.exports = {
         ],
       },
       {
-        test: /\.mdx?$/,
+        test: /\.(mdx|map)?$/,
         loader: 'ignore-loader',
       },
       {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.8.3",
+  "version": "8.8.4",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {
@@ -84,6 +84,7 @@
     "html-webpack-plugin": "^5.5.0",
     "http-proxy-middleware": "^3.0.2",
     "identity-obj-proxy": "^3.0.0",
+    "ignore-loader": "^0.1.2",
     "intersection-observer": "^0.12.0",
     "jest": "^27.4.3",
     "jest-resolve": "^27.4.2",


### PR DESCRIPTION
### Issue
When running cypress in apps, a new error came up where it doesn't know how to load the .map files from node_modules. I don't think we need them, but we can adjust this in the future if needed.

### Screenshots
**Before (tests still run and pass):**
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/ae31938e-0630-4999-8022-9ee49f4614c3" />
**After (no map loading errors):**
<img width="865" alt="image" src="https://github.com/user-attachments/assets/a20dff33-f138-478e-b2f3-36367cb4a9dc" />
