### PR TITLE
Add REACT_APP_INJECT_STYLES to allow injecting generated styles into window variable

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,4 +1,4 @@
-## 8.6.0
+## 8.9.0
 
 - Add options for injecting scripts and styles (for hf-inj-react)
 

--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,4 +1,4 @@
-## 8.8.5
+## 8.6.0
 
 - Add options for injecting scripts and styles (for hf-inj-react)
 

--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,7 @@
+## 8.8.5
+
+- Add options for injecting scripts and styles (for hf-inj-react)
+
 ## 8.8.3
 
 - Add photos/apiHelper endpoint to proxy list

--- a/packages/react-scripts/config/InjectEntrypointsPlugin.js
+++ b/packages/react-scripts/config/InjectEntrypointsPlugin.js
@@ -15,8 +15,11 @@ class InjectEntrypointsPlugin {
 	afterEmit.tap('InjectEntrypointsPlugin', (manifest) => {
 		const outputPath = path.join(
 			compiler.options.context,
+			'build-hf',
 			this.options.outputFile
 		);
+
+		fs.mkdirSync(path.dirname(outputPath));
 
 		fs.writeFileSync(outputPath,
 			JSON.stringify(

--- a/packages/react-scripts/config/InjectEntrypointsPlugin.js
+++ b/packages/react-scripts/config/InjectEntrypointsPlugin.js
@@ -1,0 +1,28 @@
+'use strict';
+const { getCompilerHooks } = require('webpack-manifest-plugin');
+const fs = require('fs');
+const path = require('path');
+
+class InjectEntrypointsPlugin {
+  constructor(options) {
+    this.options = options;
+  }
+
+  apply(compiler) {
+	const {afterEmit} = getCompilerHooks(compiler)
+
+	afterEmit.tap('InjectEntrypointsPlugin', (manifest) => {
+		const outputPath = path.join(
+			compiler.options.context,
+			this.options.outputFile
+		);
+
+		fs.writeFileSync(outputPath,
+			JSON.stringify(
+				manifest.entrypoints.map((entry) => this.options.outputPath + entry)),
+				'utf8');
+			})
+  }
+}
+
+module.exports = InjectEntrypointsPlugin;

--- a/packages/react-scripts/config/InjectEntrypointsPlugin.js
+++ b/packages/react-scripts/config/InjectEntrypointsPlugin.js
@@ -2,7 +2,7 @@
 const { getCompilerHooks } = require('webpack-manifest-plugin');
 const fs = require('fs');
 const path = require('path');
-const paths = require('./paths')
+const paths = require('./paths');
 
 class InjectEntrypointsPlugin {
   constructor(options) {

--- a/packages/react-scripts/config/InjectEntrypointsPlugin.js
+++ b/packages/react-scripts/config/InjectEntrypointsPlugin.js
@@ -2,6 +2,7 @@
 const { getCompilerHooks } = require('webpack-manifest-plugin');
 const fs = require('fs');
 const path = require('path');
+const paths = require('./paths')
 
 class InjectEntrypointsPlugin {
   constructor(options) {
@@ -19,7 +20,7 @@ class InjectEntrypointsPlugin {
 
 		fs.writeFileSync(outputPath,
 			JSON.stringify(
-				manifest.entrypoints.map((entry) => this.options.outputPath + entry)),
+				manifest.entrypoints.map((entry) => paths.publicUrlOrPath + entry)),
 				'utf8');
 			})
   }

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -741,7 +741,7 @@ module.exports = function (webpackEnv) {
       // a plugin that prints an error when you attempt to do this.
       // See https://github.com/facebook/create-react-app/issues/240
       isEnvDevelopment && new CaseSensitivePathsPlugin(),
-      (isEnvProduction && !process.env.REACT_APP_INJECT_STYLES) &&
+      (isEnvProduction && process.env.REACT_APP_INJECT_STYLES !== 'true') &&
         new MiniCssExtractPlugin({
           // Options similar to the same options in webpackOptions.output
           // both options are optional

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -60,6 +60,7 @@ console.log(`In webpack.config from @fs/react-scripts version ${reactScriptsVers
 const getCacheIdentifier = require('react-dev-utils/getCacheIdentifier')
 // @remove-on-eject-end
 const createEnvironmentHash = require('./webpack/persistentCache/createEnvironmentHash')
+const InjectEntrypointsPlugin = require('./InjectEntrypointsPlugin.js')
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
 const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false'
@@ -139,6 +140,7 @@ module.exports = function (webpackEnv) {
 
   // common function to get style loaders
   const getStyleLoaders = (cssOptions, preProcessor) => {
+    // todo handle inject styles for prod
     const loaders = [
       isEnvDevelopment && {
         loader: require.resolve('style-loader'),
@@ -770,6 +772,12 @@ module.exports = function (webpackEnv) {
             entrypoints: entrypointFiles,
           }
         },
+      }),
+      // Inject the manifest entrypoint file names into the outputFile
+      process.env.REACT_APP_INJECT_SCRIPTS == 'true' &&
+      new InjectEntrypointsPlugin({
+        outputPath: paths.publicUrlOrPath,
+        outputFile: 'hf-inj-react-scripts.js',
       }),
       // Moment.js is an extremely popular library that bundles large locale files
       // by default due to how webpack interprets its code. This is a practical

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -141,7 +141,7 @@ module.exports = function (webpackEnv) {
   // common function to get style loaders
   const getStyleLoaders = (cssOptions, preProcessor) => {
     const loaders = [
-      (isEnvDevelopment || process.env.REACT_APP_INJECT_STYLES) && {
+      (isEnvDevelopment || process.env.REACT_APP_INJECT_STYLES === 'true') && {
         loader: require.resolve('style-loader'),
         options: process.env.REACT_APP_INJECT_STYLES === 'true' ? {
           injectType: 'singletonStyleTag',

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -773,7 +773,7 @@ module.exports = function (webpackEnv) {
         },
       }),
       // Inject the manifest entrypoint file names into the outputFile
-      process.env.REACT_APP_INJECT_SCRIPTS == 'true' &&
+      process.env.REACT_APP_INJECT_SCRIPTS === 'true' &&
       new InjectEntrypointsPlugin({
         outputPath: paths.publicUrlOrPath,
         outputFile: 'hf-inj-react-scripts.js',

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -140,9 +140,8 @@ module.exports = function (webpackEnv) {
 
   // common function to get style loaders
   const getStyleLoaders = (cssOptions, preProcessor) => {
-    // todo handle inject styles for prod
     const loaders = [
-      isEnvDevelopment && {
+      (isEnvDevelopment || process.env.REACT_APP_INJECT_STYLES) && {
         loader: require.resolve('style-loader'),
         options: process.env.REACT_APP_INJECT_STYLES ? {
           injectType: 'singletonStyleTag',
@@ -152,7 +151,7 @@ module.exports = function (webpackEnv) {
           }
         } : {},
       },
-      isEnvProduction && {
+      (isEnvProduction && !process.env.REACT_APP_INJECT_STYLES) && {
         loader: MiniCssExtractPlugin.loader,
         // css is located in `static/css`, use '../../' to locate index.html folder
         // in production `paths.publicUrlOrPath` can be a relative path
@@ -742,7 +741,7 @@ module.exports = function (webpackEnv) {
       // a plugin that prints an error when you attempt to do this.
       // See https://github.com/facebook/create-react-app/issues/240
       isEnvDevelopment && new CaseSensitivePathsPlugin(),
-      isEnvProduction &&
+      (isEnvProduction && !process.env.REACT_APP_INJECT_STYLES) &&
         new MiniCssExtractPlugin({
           // Options similar to the same options in webpackOptions.output
           // both options are optional

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -775,7 +775,7 @@ module.exports = function (webpackEnv) {
       // Inject the manifest entrypoint file names into the outputFile
       process.env.INJECT_SCRIPTS === 'true' &&
       new InjectEntrypointsPlugin({
-        outputFile: 'hf-inj-react-scripts.js',
+        outputFile: 'hf-inj-react-scripts.json',
       }),
       // Moment.js is an extremely popular library that bundles large locale files
       // by default due to how webpack interprets its code. This is a practical

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -140,7 +140,16 @@ module.exports = function (webpackEnv) {
   // common function to get style loaders
   const getStyleLoaders = (cssOptions, preProcessor) => {
     const loaders = [
-      isEnvDevelopment && require.resolve('style-loader'),
+      isEnvDevelopment && {
+        loader: require.resolve('style-loader'),
+        options: process.env.REACT_APP_INJECT_STYLES ? {
+          injectType: 'singletonStyleTag',
+          insert: function addToWindowObject(element) {
+            const _window = typeof window !== 'undefined' ? window : {}
+            _window[process.env.REACT_APP_INJECT_STYLES] = element
+          }
+        } : {},
+      },
       isEnvProduction && {
         loader: MiniCssExtractPlugin.loader,
         // css is located in `static/css`, use '../../' to locate index.html folder

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -143,7 +143,7 @@ module.exports = function (webpackEnv) {
     const loaders = [
       (isEnvDevelopment || process.env.REACT_APP_INJECT_STYLES) && {
         loader: require.resolve('style-loader'),
-        options: process.env.REACT_APP_INJECT_STYLES ? {
+        options: process.env.REACT_APP_INJECT_STYLES === 'true' ? {
           injectType: 'singletonStyleTag',
           insert: function addToWindowObject(element) {
             const _window = typeof window !== 'undefined' ? window : {}

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -141,17 +141,17 @@ module.exports = function (webpackEnv) {
   // common function to get style loaders
   const getStyleLoaders = (cssOptions, preProcessor) => {
     const loaders = [
-      (isEnvDevelopment || process.env.REACT_APP_INJECT_STYLES === 'true') && {
+      (isEnvDevelopment || process.env.INJECT_STYLES === 'true') && {
         loader: require.resolve('style-loader'),
-        options: process.env.REACT_APP_INJECT_STYLES === 'true' ? {
+        options: process.env.INJECT_STYLES === 'true' ? {
           injectType: 'singletonStyleTag',
           insert: function addToWindowObject(element) {
             const _window = typeof window !== 'undefined' ? window : {}
-            _window[process.env.REACT_APP_INJECT_STYLES] = element
+            _window['hfBundleStyles'] = element
           }
         } : {},
       },
-      (isEnvProduction && !process.env.REACT_APP_INJECT_STYLES) && {
+      (isEnvProduction && !process.env.INJECT_STYLES) && {
         loader: MiniCssExtractPlugin.loader,
         // css is located in `static/css`, use '../../' to locate index.html folder
         // in production `paths.publicUrlOrPath` can be a relative path
@@ -741,7 +741,7 @@ module.exports = function (webpackEnv) {
       // a plugin that prints an error when you attempt to do this.
       // See https://github.com/facebook/create-react-app/issues/240
       isEnvDevelopment && new CaseSensitivePathsPlugin(),
-      (isEnvProduction && process.env.REACT_APP_INJECT_STYLES !== 'true') &&
+      (isEnvProduction && process.env.INJECT_STYLES !== 'true') &&
         new MiniCssExtractPlugin({
           // Options similar to the same options in webpackOptions.output
           // both options are optional
@@ -773,9 +773,8 @@ module.exports = function (webpackEnv) {
         },
       }),
       // Inject the manifest entrypoint file names into the outputFile
-      process.env.REACT_APP_INJECT_SCRIPTS === 'true' &&
+      process.env.INJECT_SCRIPTS === 'true' &&
       new InjectEntrypointsPlugin({
-        outputPath: paths.publicUrlOrPath,
         outputFile: 'hf-inj-react-scripts.js',
       }),
       // Moment.js is an extremely popular library that bundles large locale files

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.8.5",
+  "version": "8.6.0",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.8.4",
+  "version": "8.8.5",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.6.0",
+  "version": "8.9.0",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
This change allows REACT_APP_INJECT_STYLES to control injecting styles into a window variable (which is then used within hf-inj-react to inject them into the shadow DOM for the zion header/footer)
The use of `style-loader` for prod builds when REACT_APP_INJECT_STYLES is enabled - instead of `MiniCssExtractPlugin` is because of the warning under this section: https://webpack.js.org/plugins/mini-css-extract-plugin/#insert that this functionality is not for initial chunks. (also documented in the `architectural decisions` of hf-inj-react)

This also introduces REACT_APP_INJECT_SCRIPTS which gets the entrypoints and makes them available in a given file. 