### PR TITLE
[@fs/react-scripts] Add colors for fr-test's jest tests

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,7 @@
+## 8.9.1
+
+- Add colors for fr-test's jest tests
+
 ## 8.9.0
 
 - Add options for injecting scripts and styles (for hf-inj-react)

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.9.0",
+  "version": "8.9.1",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/fr-test.js
+++ b/packages/react-scripts/scripts/fr-test.js
@@ -47,7 +47,7 @@ if(cypressTestsExist){
 
 if(jestTestsExist){
   console.log('RUNNING JEST TESTS')
-  execSync('react-scripts test --coverage', { cwd: process.cwd(), stdio: 'inherit' })
+  execSync('react-scripts test --coverage --colors', { cwd: process.cwd(), stdio: 'inherit' })
 }
 
 // If both types exist, merge coverage reports


### PR DESCRIPTION
This makes it so we have colors for the jest tests like we do for the cypress tests. It makes it easier to read, especially if you have text-summary.

before:
![image](https://github.com/user-attachments/assets/57bdc750-3217-454f-821c-3f65d9cb68e1)

after:
![image](https://github.com/user-attachments/assets/6cf26b94-b5d8-4d5d-ab48-ff1cb15aefd5)

before with text-summary:
![image](https://github.com/user-attachments/assets/368e4e02-fe73-407c-b7a6-3aff9089b122)

after with text-summary:
![image](https://github.com/user-attachments/assets/90f58d7e-e4f0-4b19-bbdc-fd1e8a197266)
