### PR TITLE
[@fs/react-scripts] Update merged test report command

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,8 @@
+## 8.10.0
+
+- Check coverage for combined cypress and jest tests
+- Show text and text-summary for combined cypress and jest tests and in color
+
 ## 8.9.1
 
 - Add colors for fr-test's jest tests

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.9.1",
+  "version": "8.10.0",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/fr-test.js
+++ b/packages/react-scripts/scripts/fr-test.js
@@ -20,7 +20,7 @@ const mergeReports = ()=>{
   // merge reports
   execSync('npx nyc merge reports .nyc_output/out.json', {stdio: 'inherit'})
   // report the coverage
-  execSync(`npx nyc report --include 'src/**/*.{js,ts,tsx}' --report-dir coverage --reporter "lcov"`, {stdio: 'inherit'})
+  execSync("npx nyc report --include 'src/**/*.{js,ts,tsx}' --report-dir coverage --reporter lcov --reporter text --reporter text-summary --check-coverage --colors", {stdio: 'inherit'})
 }
 // dev ran npm test
 if(!process.env.CI){


### PR DESCRIPTION
- Check coverage for combined cypress and jest tests
- Show text and text-summary for combined cypress and jest tests and in color

Note: we have had this in our group-management repo that was piloting cypress in apps for 6 months ([(https://github.com/fs-webdev/group-management/blob/master/scripts/test.js#L32](https://github.com/fs-webdev/group-management/blob/frontier-group-management-b1156/scripts/test.js#L32))

--check-coverage
checks that the combined coverage beats the numbers defined in nyc.config.js
For example, in this case we have `lines: 80`, and since our coverage is below that (at 74.41% instead of 80% or higher), the process fails.
Note the default values from the migration script are
```
  branches: 50,
  lines: 60,
  functions: 50,
  statements: 60,
```
With higher coverage requirements to show failure:
![image](https://github.com/user-attachments/assets/79e7434e-b23b-457c-a0fa-7d7f18c605f3)

![image](https://github.com/user-attachments/assets/9e5596f8-7278-49a2-b85b-d257a096cebe)


--reporter text
shows the details of file coverage
![image](https://github.com/user-attachments/assets/88de6c9e-c629-48fb-8262-bc3ef6af5af9)


--reporter text-summary
show the summary of coverage
![image](https://github.com/user-attachments/assets/96fda896-65e4-4196-9149-f5b7a7a36dd6)


-- colors
without it, we won't have colors for the text and text-summary
![image](https://github.com/user-attachments/assets/b909de34-94ee-4a45-872f-f102a4848587)


Note: Remember that this command, to show merged report, only runs if there are both jest and cypress tests.