### PR TITLE
Add support for emotion in cypress component tests

### DIFF
--- a/packages/react-scripts/config/simple-webpack.config.js
+++ b/packages/react-scripts/config/simple-webpack.config.js
@@ -35,6 +35,7 @@ module.exports = {
           {
             loader: 'babel-loader',
             options: {
+              presets: babelConfig.presets,
               plugins: babelConfig.plugins,
             },
           },
@@ -49,6 +50,7 @@ module.exports = {
             loader: 'babel-loader',
             options: {
               plugins: [
+                '@emotion',
                 [
                   'istanbul',
                   {
@@ -77,7 +79,11 @@ module.exports = {
                   },
                 ],
               ],
-              presets: ['@babel/preset-react'],
+              presets: [
+                '@babel/preset-env',
+                '@babel/preset-react',
+                '@emotion/babel-preset-css-prop'
+              ],
               ignore: ['**/dist/*'],
               babelrc: false,
             },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.9.1",
+  "version": "8.9.2",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
In the beginning, I copied most of this webpack config from zion which doesn't support emotion.

### Changes
* Add support for emotion in cypress component tests.

### Screenshots
I tested it by adding emotion styles to the text below the button
**Before**
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/48ee6ef8-8010-4958-87b8-cd93a2e4edd8" />

**After**
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/633cb04e-a68f-4af3-aa15-eabb6ac531ae" />
