### PR TITLE
Support TypeScript Cypress tests in apps

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,11 @@
+## 8.10.2
+
+- Support TypeScript Cypress tests in a TypeScript app
+
+## 8.10.1
+
+- Add support for emotion in cypress component tests
+
 ## 8.10.0
 
 - Check coverage for combined cypress and jest tests

--- a/packages/react-scripts/config/simple-webpack.config.js
+++ b/packages/react-scripts/config/simple-webpack.config.js
@@ -82,6 +82,7 @@ module.exports = {
               presets: [
                 '@babel/preset-env',
                 '@babel/preset-react',
+                '@babel/preset-typescript',
                 '@emotion/babel-preset-css-prop'
               ],
               ignore: ['**/dist/*'],

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.10.1",
+  "version": "8.10.2",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
When fr-migrating tree-person-r9, cypress was throwing an error when declaring or using a type in a cypress test like so:
![image](https://github.com/user-attachments/assets/e03731c4-b49b-48c4-b780-b4bac5805bea)

I didn't have this issue in ancestors-r9. ancestors-r9 has its own babel config due to the special nature of ancestors-r9. I was able to figure out that the `@babel/preset-typescript` in the babel config is what allowed ancestors-r9 to work with types in its cypress tests and tree-person-r9 not. I was able to test it in tree-person-r9 by directly adding `@babel/preset-typescript` as a preset in @fs/react-scripts in tree-person-r9's node modules. This pr makes it official so we can consume it in tree-person-r9.