### PR TITLE
Read logoHref from snow res.locals for apple-touch-icon for PWAs

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,9 @@
+## 8.10.5
+
+- Add intelligence to `layout.ejs` to use the correct icon for PWAs saved to homescreen.
+- Update package.json to use `prepublishOnly` to run modernizr on layout.
+- Update `README-FRONTIER.md` to reflect the correct steps for testing local changes to `react-scripts`.
+
 ## 8.10.4
 
 - Add @emotion/babel-plugin for cypress tests in apps

--- a/README-FRONTIER.md
+++ b/README-FRONTIER.md
@@ -16,9 +16,11 @@ That being said, if you want to use our fork "manually", then here is how you do
 If you have cloned this repo and made changes locally and want to test them before committing and publishing here is how.
 
 1. Clone this repo and make any changes needed in `./packages/react-scripts/`
-2. Change directories to where you want a brand new app to be created in (don't run step 3 in an existing repo)
-3. Run the following command  
+2. In the `react-scripts` directory run `npm install`.
+3. Change directories to where you want a brand new app to be created in (don't run step 4 in an existing repo)
+4. Run the following command  
    `npx create-react-app --use-npm --template @fs/cra-template --scripts-version file:${relativePathToYourClonedCreateReactAppRepo}/packages/react-scripts ${your-app-name} `
+
 
 ## Development and Cutting a Release
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4937,6 +4937,25 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
     "node_modules/@emotion/babel-plugin-jsx-pragmatic": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.1.5.tgz",
@@ -4947,6 +4966,58 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@emotion/babel-preset-css-prop": {
@@ -35468,6 +35539,12 @@
         "postcss": "^8.2.15"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
     "node_modules/stylus-lookup": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-5.0.1.tgz",
@@ -41175,10 +41252,11 @@
     },
     "packages/react-scripts": {
       "name": "@fs/react-scripts",
-      "version": "8.8.3",
+      "version": "8.10.5",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
+        "@emotion/babel-plugin": "^11.13.5",
         "@fs/auth-middleware": "^2.0.1",
         "@fs/babel-preset-frontier": "^5.0.0",
         "@fs/webpack-wci18n": "^1.0.0",

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -14,8 +14,10 @@
     <meta name="description" content="Discover your family history. Explore the world’s largest collection of free family trees, genealogy records and resources.">
     <meta name="google-site-verification" content="VJlFQrAXTCBy0PqVi23EsGD-mpA5KaBhIt8LkrcRbP0" />
     <link href="https://edge.fscdn.org/assets/docs/fs_logo_favicon_sq.png" rel="icon" type="image/x-icon" />
-    <link rel="apple-touch-icon" href="https://edge.fscdn.org/assets/components/hf/assets/img/tree-touch-icon-11024a277f1fda5735de5a9f0f4f75ca.png" />
-
+    
+    <!-- icon used for PWAs saved to homescreen -->
+    <link rel="apple-touch-icon" href="<%= typeof logoHref !== 'undefined' ? logoHref : 'https://edge.fscdn.org/assets/components/hf/assets/img/tree-touch-icon-11024a277f1fda5735de5a9f0f4f75ca.png' %>" />
+    
     <% if (typeof manifestJsonExists === 'undefined' || manifestJsonExists) { %>
       <link rel="manifest" href="<%= typeof appPathOverride !== 'undefined' ? appPathOverride : appPath('') %>/manifest.json" type="application/manifest+json" crossorigin="use-credentials" />
     <% } %>

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.10.4",
+  "version": "8.10.5",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {
@@ -18,7 +18,7 @@
   "scripts": {
     "prettier": "npx prettier --arrow-parens always --single-quote --trailing-comma es5 --print-width 120 --no-semi --write \"template*/**/*.js\"",
     "fs-publish": "npmPublish",
-    "prepare": "modernizr -c modernizr-config.json -d layout"
+    "prepublishOnly": "npx modernizr -c modernizr-config.json -d layout"
   },
   "files": [
     "bin",


### PR DESCRIPTION
This is the create-react-app part of the fix for https://icseng.atlassian.net/browse/FRONTIER-1197.

We are adding a value logoHref to Snow's res.locals for usage in `layout.ejs` of frontier's react-scripts.

This value is assigned from the app's `manifest.json` if it exists, and the logo exists in it. Otherwise, the standard tree logo is assigned to it instead.

Also, updated instructions for making changes in README-FRONTIER.