### PR TITLE
add support for .avif files in simple-webpack-config

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,7 @@
+## 8.10.8
+
+- Add support for .avif files in simple-webpack-config
+
 ## 8.10.7
 
 - Rename released proposal plugins to transform plugins

--- a/packages/react-scripts/config/simple-webpack.config.js
+++ b/packages/react-scripts/config/simple-webpack.config.js
@@ -96,7 +96,7 @@ module.exports = {
         loader: 'ignore-loader',
       },
       {
-        test: /\.(ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\?.*)?$/,
+        test: /\.(ico|jpg|jpeg|png|apng|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf|avif)(\?.*)?$/,
         loader: require.resolve('file-loader'),
         options: {
           esModule: false,

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.10.7",
+  "version": "8.10.8",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
One of the interns used an avif file in their profile which broke cypress. Avif files have 93% browser support, so I see no reason to not allow it generally in testing contexts across the site. The main webpack config already supports it, this just adds it to simple-webpack.config for cypress testing.