### PR TITLE
Add flag to remove head tag from webpack script insert

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,7 @@
+## 8.10.9
+
+- Add flag to ensure no double head tag inserted in template (https://icseng.atlassian.net/browse/ACCESSIBLE-88)
+
 ## 8.10.8
 
 - Add support for .avif files in simple-webpack-config

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -699,6 +699,9 @@ module.exports = function (webpackEnv) {
                   minifyJS: true,
                   minifyCSS: true,
                   minifyURLs: true,
+                  // This avoids inserting an extraneous <head> tag in the output HTML
+                  // See https://icseng.atlassian.net/browse/ACCESSIBLE-88
+                  removeOptionalTags: true, 
                 },
               }
             : undefined


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Webpack was inserting scripts into the base index.html template nested in an extra <head> tag. I added the removeOptionalTags flag to the HtmlWebpackPlugin, which modifies the generated scripts file to only have the HTML elements necessary to load the scripts and styles for Webpack.

[Jira](https://icseng.atlassian.net/browse/ACCESSIBLE-88)