### PR TITLE
[8.10.10] fix duplicate head tags in dev mode

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,7 @@
+## 8.10.10
+
+- Apply head tag fix from 8.10.9 to dev mode as well as prod mode
+
 ## 8.10.9
 
 - Add flag to ensure no double head tag inserted in template (https://icseng.atlassian.net/browse/ACCESSIBLE-88)

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -704,7 +704,13 @@ module.exports = function (webpackEnv) {
                   removeOptionalTags: true, 
                 },
               }
-            : undefined
+            : {
+                minify: {
+                  // This avoids inserting an extraneous <head> tag in the output HTML
+                  // See https://icseng.atlassian.net/browse/ACCESSIBLE-88
+                  removeOptionalTags: true,
+                },
+              }
         )
       ),
       // Inlines the webpack runtime script. This script is too small to warrant

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.10.9",
+  "version": "8.10.10",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
This applies the fix from 8.10.9 to avoid duplicate head tags to dev mode as well as prod mode.
I confirmed that the only change is to the head tags, and it doesn't minify any other dev mode values in a problematic way:

```
< <script defer="defer" src="/static/js/commonVendor.js"></script><script defer="defer" src="/static/js/vendors-node_modules_emotion_core_dist_core_browser_esm_js-node_modules_fs_react-scripts_poly-0786f6.js"></script><script defer="defer" src="/static/js/main.js"></script><link rel="manifest" href="/manifest.json">
---
> <head><script defer src="/static/js/commonVendor.js"></script><script defer src="/static/js/vendors-node_modules_emotion_core_dist_core_browser_esm_js-node_modules_fs_react-scripts_poly-0786f6.js"></script><script defer src="/static/js/main.js"></script></head><link rel="manifest" href="/manifest.json" />
```