### PR TITLE
added config to handle process in mjs files

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,7 @@
+## 8.10.12
+
+- Update simple-webpack-config to handle `process` from mjs files
+
 ## 8.10.11
 
 - Pass `flagAttributes` from Snow to SERVER_DATA for use in zion-config

--- a/packages/react-scripts/config/simple-webpack.config.js
+++ b/packages/react-scripts/config/simple-webpack.config.js
@@ -25,6 +25,7 @@ module.exports = {
       // '@material-ui/styles': require.resolve('@material-ui/styles'),
       '/coalesced-locales': path.resolve(path.join(process.cwd(), 'dist/locales/')),
     },
+    fallback: { 'process/browser': require.resolve('process/browser') },
     extensions: ['.ts', '.tsx', '.jsx', '.js', '.json'],
   },
   module: {
@@ -40,7 +41,7 @@ module.exports = {
             },
           },
         ],
-        include: (input) => input.match(d3DagRegex),
+        include: input => input.match(d3DagRegex),
       },
       {
         test: /\.(mjs|tsx?|jsx?)$/,
@@ -83,7 +84,7 @@ module.exports = {
                 '@babel/preset-env',
                 '@babel/preset-react',
                 '@babel/preset-typescript',
-                '@emotion/babel-preset-css-prop'
+                '@emotion/babel-preset-css-prop',
               ],
               ignore: ['**/dist/*'],
               babelrc: false,
@@ -123,7 +124,7 @@ module.exports = {
             options: {
               esModule: false,
               name: 'static/media/[path][name].[ext]',
-            }
+            },
           },
         ],
       },
@@ -152,6 +153,7 @@ module.exports = {
     new MiniCssExtractPlugin({ filename: 'styles.css', ignoreOrder: true }),
     new webpack.ProvidePlugin({
       React: 'react',
+      process: 'process/browser',
     }),
     new RetryChunkLoadPlugin({
       // optional stringified function to get the cache busting query string appended to the script src

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.10.11",
+  "version": "8.10.12",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
While updating flags-js output to be a module, we ran into an issue where cypress tests weren't able to resolve `process`. It turns out we needed some additional config in simple-webpack-config to handle that for us.