### PR TITLE
Adding Warnings to Enable Cookies and Javascript

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,7 @@
+## 8.11.0 
+
+- Add no cookies and no javascript warnings to react-scripts
+  
 ## 8.10.12
 
 - Update simple-webpack-config to handle `process` from mjs files

--- a/README-FRONTIER.md
+++ b/README-FRONTIER.md
@@ -21,6 +21,9 @@ If you have cloned this repo and made changes locally and want to test them befo
 4. Run the following command  
    `npx create-react-app --use-npm --template @fs/cra-template --scripts-version file:${relativePathToYourClonedCreateReactAppRepo}/packages/react-scripts ${your-app-name} `
 
+## Linking react-scripts to another app 
+
+Before running `npm link`, run `npm publish --dry-run` to ensure modernizr.js is added in `./packages/react-scripts/layout`
 
 ## Development and Cutting a Release
 
@@ -43,3 +46,4 @@ When we are ready to pull in changes from Facebook, here are the steps
 7. Fix any merge conflicts
 8. Bump the 'upstreamVersion' in packages/react-scripts/package.json to match the release of facebook's react-scripts that you merged to
 9. Cut a release (follow steps up above)
+

--- a/README-FRONTIER.md
+++ b/README-FRONTIER.md
@@ -46,4 +46,3 @@ When we are ready to pull in changes from Facebook, here are the steps
 7. Fix any merge conflicts
 8. Bump the 'upstreamVersion' in packages/react-scripts/package.json to match the release of facebook's react-scripts that you merged to
 9. Cut a release (follow steps up above)
-

--- a/packages/react-scripts/layout/index.js
+++ b/packages/react-scripts/layout/index.js
@@ -10,6 +10,7 @@ const config = {
       here for some potential fixes. https://www.familysearch.org/frontier/docs/miscellaneous/common-issues`,
     },
   ],
+  localesDir: __dirname + `/locales`
 }
 
 module.exports = config

--- a/packages/react-scripts/layout/index.js
+++ b/packages/react-scripts/layout/index.js
@@ -10,7 +10,6 @@ const config = {
       here for some potential fixes. https://www.familysearch.org/frontier/docs/miscellaneous/common-issues`,
     },
   ],
-  localesDir: __dirname + `/locales`
 }
 
 module.exports = config

--- a/packages/react-scripts/layout/locales/layout_en.json
+++ b/packages/react-scripts/layout/locales/layout_en.json
@@ -1,0 +1,9 @@
+{ "noscript-title" : "JavaScript is required to use FamilySearch",
+  "noscript-message" : "It looks like JavaScript is disabled in your browser. FamilySearch requires JavaScript to function properly.",
+  "noscript-last-message" : "To continue, please enable JavaScript in your browser settings and refresh the page.",
+  "noscript-link" : "Learn how to enable JavaScript",
+  "nocookies-title" : "Cookies are required to use FamilySearch",
+  "nocookies-message" : "It looks like cookies are disabled in your browser. FamilySearch requires cookies to function properly.",
+  "nocookies-last-message" : "To continue, please enable cookies in your browser settings and refresh the page.",
+  "nocookies-link" : "Learn how to enable cookies"
+}

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -61,6 +61,128 @@
         window.dtinfo.appName = SERVER_DATA.appName
       }
     </script>
+
+    <!-- No Cookies Warning --> 
+    <style>
+      .nocookies-container {
+        display: none;
+        flex-direction: column;
+        justify-content: center;
+        min-height: 100vh;
+        font-family: sans-serif;
+        max-width: 550px;
+        margin: 0 auto;
+      }
+
+      .nocookies-link {
+        display: inline-block;
+        border: 1px solid black;
+        color: black;
+        padding: 10px 20px;
+        text-decoration: none;
+        border-radius: 8px;
+      }
+
+      .nocookies-message {
+        margin-bottom: 10px;
+      }
+
+      .nocookies-last-message {
+        margin-bottom: 20px;
+      }
+
+      .nocookies-container svg {
+        display: flex;
+        align-self: center;
+        max-width: 72px;
+        height: auto;
+        margin-bottom: 20px;
+      }
+    </style>
+    <div id="nocookies-warning" class="nocookies-container">
+      <svg fill="none"><path stroke="#B5B8B8" stroke-dasharray="3 5" stroke-linecap="round" stroke-width="2" d="M28.92 1c56.58 65.5 0 73.14 0 50.32S68.5 31.5 52.68 80.022" style="stroke:#b5b8b8;stroke:color(display-p3 .7098 .7216 .7216);stroke-opacity:1"/><path fill="#83AF1D" d="M11.23 127.312s-1.742-17.022 7.845-27.404c9.586-10.383 26.711-10.204 26.711-10.204s1.742 17.022-7.844 27.405c-9.587 10.382-26.712 10.203-26.712 10.203Z" style="fill:#83af1d;fill:color(display-p3 .5137 .6863 .1137);fill-opacity:1"/><path fill="#A7C41A" fill-rule="evenodd" d="M48.621 86.664c.478.442.188 1.133 0 1.336l-30.516 32.374a.5.5 0 0 1-.733-.68L47.5 86.664c.188-.203.643-.442 1.121 0Z" clip-rule="evenodd" style="fill:#a7c41a;fill:color(display-p3 .6549 .7686 .102);fill-opacity:1"/><path stroke="#A7C41A" stroke-linecap="round" d="m16.708 114.07 6.517.148 1.795 5.411m6.666-6.37-2.295-5.383-6.625-2.145m14.56.714-1.795-5.411-7.071-1.12" style="stroke:#a7c41a;stroke:color(display-p3 .6549 .7686 .102);stroke-opacity:1"/></svg>
+      <h1>Cookies are required to use FamilySearch</h1>
+      <p class="nocookies-message">It looks like cookies are disabled in your browser. FamilySearch requires cookies to function properly.</p>
+      <p class="nocookies-last-message">To continue, please enable cookies in your browser settings and refresh the page.</p>
+      <p>
+        <a href="https://www.whatismybrowser.com/guides/how-to-enable-cookies/" target="_blank" rel="noopener noreferrer" class="nocookies-link">Learn how to enable cookies</a>
+      </p>
+    </div>
+
+    <!-- Check if cookies are enabled -->
+    <script>
+      (function() {
+        try {
+          document.cookie = "cookietest=1; SameSite=Lax; path=/";
+          var cookiesEnabled = document.cookie.indexOf("cookietest") !== -1;
+
+          if (cookiesEnabled) {
+            document.cookie = "cookietest=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+          }
+
+          if (!cookiesEnabled) {
+            var warningElement = document.querySelector(".nocookies-container");
+            if (warningElement) {
+              warningElement.style.display = "flex";
+            }
+          }
+        } catch (e) {
+          var warningElement = document.querySelector(".nocookies-container");
+          if (warningElement) {
+            warningElement.style.display = "flex";
+          }
+        }
+      })();
+    </script>
+
+    <!-- NoScript Warning -->
+    <noscript>
+      <style>
+        .noscript-container {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          min-height: 100vh;
+          font-family: sans-serif;
+          max-width: 550px;
+          margin: 0 auto;
+        }
+
+        .noscript-link {
+          display: inline-block; 
+          border: 1px solid black;
+          color: black;
+          padding: 10px 20px;
+          text-decoration: none; 
+          border-radius: 8px; 
+        }
+
+        .noscript-message {
+          margin-bottom: 10px;
+        }
+
+        .noscript-last-message {
+          margin-bottom: 20px;
+        }
+
+        .noscript-container svg {
+          display: flex;
+          align-self: center;
+          max-width: 72px;
+          height: auto;
+          margin-bottom: 20px;
+        }
+      </style>
+      <div class="noscript-container">
+        <svg fill="none"><path stroke="#B5B8B8" stroke-dasharray="3 5" stroke-linecap="round" stroke-width="2" d="M28.92 1c56.58 65.5 0 73.14 0 50.32S68.5 31.5 52.68 80.022" style="stroke:#b5b8b8;stroke:color(display-p3 .7098 .7216 .7216);stroke-opacity:1"/><path fill="#83AF1D" d="M11.23 127.312s-1.742-17.022 7.845-27.404c9.586-10.383 26.711-10.204 26.711-10.204s1.742 17.022-7.844 27.405c-9.587 10.382-26.712 10.203-26.712 10.203Z" style="fill:#83af1d;fill:color(display-p3 .5137 .6863 .1137);fill-opacity:1"/><path fill="#A7C41A" fill-rule="evenodd" d="M48.621 86.664c.478.442.188 1.133 0 1.336l-30.516 32.374a.5.5 0 0 1-.733-.68L47.5 86.664c.188-.203.643-.442 1.121 0Z" clip-rule="evenodd" style="fill:#a7c41a;fill:color(display-p3 .6549 .7686 .102);fill-opacity:1"/><path stroke="#A7C41A" stroke-linecap="round" d="m16.708 114.07 6.517.148 1.795 5.411m6.666-6.37-2.295-5.383-6.625-2.145m14.56.714-1.795-5.411-7.071-1.12" style="stroke:#a7c41a;stroke:color(display-p3 .6549 .7686 .102);stroke-opacity:1"/></svg>
+        <h1>JavaScript is required to use FamilySearch</h1>
+        <p class="noscript-message">It looks like JavaScript is disabled in your browser. FamilySearch requires JavaScript to function properly.</p>
+        <p class="noscript-last-message">To continue, please enable JavaScript in your browser settings and refresh the page.</p>
+        <p>
+          <a href="https://www.enable-javascript.com/" target="_blank" rel="noopener noreferrer" class="noscript-link">Learn how to enable JavaScript</a>
+        </p>
+      </div>
+    </noscript>
   </head>
   <body>
     <% if (getFeatureFlag('frontier_snow_unsupportedBrowser').isOn) { %>

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -101,11 +101,11 @@
     </style>
     <div id="nocookies-warning" class="nocookies-container">
       <svg fill="none"><path stroke="#B5B8B8" stroke-dasharray="3 5" stroke-linecap="round" stroke-width="2" d="M28.92 1c56.58 65.5 0 73.14 0 50.32S68.5 31.5 52.68 80.022" style="stroke:#b5b8b8;stroke:color(display-p3 .7098 .7216 .7216);stroke-opacity:1"/><path fill="#83AF1D" d="M11.23 127.312s-1.742-17.022 7.845-27.404c9.586-10.383 26.711-10.204 26.711-10.204s1.742 17.022-7.844 27.405c-9.587 10.382-26.712 10.203-26.712 10.203Z" style="fill:#83af1d;fill:color(display-p3 .5137 .6863 .1137);fill-opacity:1"/><path fill="#A7C41A" fill-rule="evenodd" d="M48.621 86.664c.478.442.188 1.133 0 1.336l-30.516 32.374a.5.5 0 0 1-.733-.68L47.5 86.664c.188-.203.643-.442 1.121 0Z" clip-rule="evenodd" style="fill:#a7c41a;fill:color(display-p3 .6549 .7686 .102);fill-opacity:1"/><path stroke="#A7C41A" stroke-linecap="round" d="m16.708 114.07 6.517.148 1.795 5.411m6.666-6.37-2.295-5.383-6.625-2.145m14.56.714-1.795-5.411-7.071-1.12" style="stroke:#a7c41a;stroke:color(display-p3 .6549 .7686 .102);stroke-opacity:1"/></svg>
-      <h1>Cookies are required to use FamilySearch</h1>
-      <p class="nocookies-message">It looks like cookies are disabled in your browser. FamilySearch requires cookies to function properly.</p>
-      <p class="nocookies-last-message">To continue, please enable cookies in your browser settings and refresh the page.</p>
+      <h1><%- i18n('nocookies-title')%></h1>
+      <p class="nocookies-message"><%- i18n('nocookies-message')%></p>
+      <p class="nocookies-last-message"><%- i18n('nocookies-last-message')%></p>
       <p>
-        <a href="https://www.whatismybrowser.com/guides/how-to-enable-cookies/" target="_blank" rel="noopener noreferrer" class="nocookies-link">Learn how to enable cookies</a>
+        <a href="https://www.whatismybrowser.com/guides/how-to-enable-cookies/" target="_blank" rel="noopener noreferrer" class="nocookies-link"><%- i18n('nocookies-link')%></a>
       </p>
     </div>
 
@@ -175,11 +175,11 @@
       </style>
       <div class="noscript-container">
         <svg fill="none"><path stroke="#B5B8B8" stroke-dasharray="3 5" stroke-linecap="round" stroke-width="2" d="M28.92 1c56.58 65.5 0 73.14 0 50.32S68.5 31.5 52.68 80.022" style="stroke:#b5b8b8;stroke:color(display-p3 .7098 .7216 .7216);stroke-opacity:1"/><path fill="#83AF1D" d="M11.23 127.312s-1.742-17.022 7.845-27.404c9.586-10.383 26.711-10.204 26.711-10.204s1.742 17.022-7.844 27.405c-9.587 10.382-26.712 10.203-26.712 10.203Z" style="fill:#83af1d;fill:color(display-p3 .5137 .6863 .1137);fill-opacity:1"/><path fill="#A7C41A" fill-rule="evenodd" d="M48.621 86.664c.478.442.188 1.133 0 1.336l-30.516 32.374a.5.5 0 0 1-.733-.68L47.5 86.664c.188-.203.643-.442 1.121 0Z" clip-rule="evenodd" style="fill:#a7c41a;fill:color(display-p3 .6549 .7686 .102);fill-opacity:1"/><path stroke="#A7C41A" stroke-linecap="round" d="m16.708 114.07 6.517.148 1.795 5.411m6.666-6.37-2.295-5.383-6.625-2.145m14.56.714-1.795-5.411-7.071-1.12" style="stroke:#a7c41a;stroke:color(display-p3 .6549 .7686 .102);stroke-opacity:1"/></svg>
-        <h1>JavaScript is required to use FamilySearch</h1>
-        <p class="noscript-message">It looks like JavaScript is disabled in your browser. FamilySearch requires JavaScript to function properly.</p>
-        <p class="noscript-last-message">To continue, please enable JavaScript in your browser settings and refresh the page.</p>
+        <h1><%- i18n('noscript-title')%></h1>
+        <p class="noscript-message"><%- i18n('noscript-message')%></p>
+        <p class="noscript-last-message"><%- i18n('noscript-last-message')%></p>
         <p>
-          <a href="https://www.enable-javascript.com/" target="_blank" rel="noopener noreferrer" class="noscript-link">Learn how to enable JavaScript</a>
+          <a href="https://www.enable-javascript.com/" target="_blank" rel="noopener noreferrer" class="noscript-link"><%- i18n('noscript-link')%></a>
         </p>
       </div>
     </noscript>

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -61,128 +61,6 @@
         window.dtinfo.appName = SERVER_DATA.appName
       }
     </script>
-
-    <!-- No Cookies Warning --> 
-    <style>
-      .nocookies-container {
-        display: none;
-        flex-direction: column;
-        justify-content: center;
-        min-height: 100vh;
-        font-family: sans-serif;
-        max-width: 550px;
-        margin: 0 auto;
-      }
-
-      .nocookies-link {
-        display: inline-block;
-        border: 1px solid black;
-        color: black;
-        padding: 10px 20px;
-        text-decoration: none;
-        border-radius: 8px;
-      }
-
-      .nocookies-message {
-        margin-bottom: 10px;
-      }
-
-      .nocookies-last-message {
-        margin-bottom: 20px;
-      }
-
-      .nocookies-container svg {
-        display: flex;
-        align-self: center;
-        max-width: 72px;
-        height: auto;
-        margin-bottom: 20px;
-      }
-    </style>
-    <div id="nocookies-warning" class="nocookies-container">
-      <svg fill="none"><path stroke="#B5B8B8" stroke-dasharray="3 5" stroke-linecap="round" stroke-width="2" d="M28.92 1c56.58 65.5 0 73.14 0 50.32S68.5 31.5 52.68 80.022" style="stroke:#b5b8b8;stroke:color(display-p3 .7098 .7216 .7216);stroke-opacity:1"/><path fill="#83AF1D" d="M11.23 127.312s-1.742-17.022 7.845-27.404c9.586-10.383 26.711-10.204 26.711-10.204s1.742 17.022-7.844 27.405c-9.587 10.382-26.712 10.203-26.712 10.203Z" style="fill:#83af1d;fill:color(display-p3 .5137 .6863 .1137);fill-opacity:1"/><path fill="#A7C41A" fill-rule="evenodd" d="M48.621 86.664c.478.442.188 1.133 0 1.336l-30.516 32.374a.5.5 0 0 1-.733-.68L47.5 86.664c.188-.203.643-.442 1.121 0Z" clip-rule="evenodd" style="fill:#a7c41a;fill:color(display-p3 .6549 .7686 .102);fill-opacity:1"/><path stroke="#A7C41A" stroke-linecap="round" d="m16.708 114.07 6.517.148 1.795 5.411m6.666-6.37-2.295-5.383-6.625-2.145m14.56.714-1.795-5.411-7.071-1.12" style="stroke:#a7c41a;stroke:color(display-p3 .6549 .7686 .102);stroke-opacity:1"/></svg>
-      <h1><%- i18n('nocookies-title')%></h1>
-      <p class="nocookies-message"><%- i18n('nocookies-message')%></p>
-      <p class="nocookies-last-message"><%- i18n('nocookies-last-message')%></p>
-      <p>
-        <a href="https://www.whatismybrowser.com/guides/how-to-enable-cookies/" target="_blank" rel="noopener noreferrer" class="nocookies-link"><%- i18n('nocookies-link')%></a>
-      </p>
-    </div>
-
-    <!-- Check if cookies are enabled -->
-    <script>
-      (function() {
-        try {
-          document.cookie = "cookietest=1; SameSite=Lax; path=/";
-          var cookiesEnabled = document.cookie.indexOf("cookietest") !== -1;
-
-          if (cookiesEnabled) {
-            document.cookie = "cookietest=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
-          }
-
-          if (!cookiesEnabled) {
-            var warningElement = document.querySelector(".nocookies-container");
-            if (warningElement) {
-              warningElement.style.display = "flex";
-            }
-          }
-        } catch (e) {
-          var warningElement = document.querySelector(".nocookies-container");
-          if (warningElement) {
-            warningElement.style.display = "flex";
-          }
-        }
-      })();
-    </script>
-
-    <!-- NoScript Warning -->
-    <noscript>
-      <style>
-        .noscript-container {
-          display: flex;
-          flex-direction: column;
-          justify-content: center;
-          min-height: 100vh;
-          font-family: sans-serif;
-          max-width: 550px;
-          margin: 0 auto;
-        }
-
-        .noscript-link {
-          display: inline-block; 
-          border: 1px solid black;
-          color: black;
-          padding: 10px 20px;
-          text-decoration: none; 
-          border-radius: 8px; 
-        }
-
-        .noscript-message {
-          margin-bottom: 10px;
-        }
-
-        .noscript-last-message {
-          margin-bottom: 20px;
-        }
-
-        .noscript-container svg {
-          display: flex;
-          align-self: center;
-          max-width: 72px;
-          height: auto;
-          margin-bottom: 20px;
-        }
-      </style>
-      <div class="noscript-container">
-        <svg fill="none"><path stroke="#B5B8B8" stroke-dasharray="3 5" stroke-linecap="round" stroke-width="2" d="M28.92 1c56.58 65.5 0 73.14 0 50.32S68.5 31.5 52.68 80.022" style="stroke:#b5b8b8;stroke:color(display-p3 .7098 .7216 .7216);stroke-opacity:1"/><path fill="#83AF1D" d="M11.23 127.312s-1.742-17.022 7.845-27.404c9.586-10.383 26.711-10.204 26.711-10.204s1.742 17.022-7.844 27.405c-9.587 10.382-26.712 10.203-26.712 10.203Z" style="fill:#83af1d;fill:color(display-p3 .5137 .6863 .1137);fill-opacity:1"/><path fill="#A7C41A" fill-rule="evenodd" d="M48.621 86.664c.478.442.188 1.133 0 1.336l-30.516 32.374a.5.5 0 0 1-.733-.68L47.5 86.664c.188-.203.643-.442 1.121 0Z" clip-rule="evenodd" style="fill:#a7c41a;fill:color(display-p3 .6549 .7686 .102);fill-opacity:1"/><path stroke="#A7C41A" stroke-linecap="round" d="m16.708 114.07 6.517.148 1.795 5.411m6.666-6.37-2.295-5.383-6.625-2.145m14.56.714-1.795-5.411-7.071-1.12" style="stroke:#a7c41a;stroke:color(display-p3 .6549 .7686 .102);stroke-opacity:1"/></svg>
-        <h1><%- i18n('noscript-title')%></h1>
-        <p class="noscript-message"><%- i18n('noscript-message')%></p>
-        <p class="noscript-last-message"><%- i18n('noscript-last-message')%></p>
-        <p>
-          <a href="https://www.enable-javascript.com/" target="_blank" rel="noopener noreferrer" class="noscript-link"><%- i18n('noscript-link')%></a>
-        </p>
-      </div>
-    </noscript>
   </head>
   <body>
     <% if (getFeatureFlag('frontier_snow_unsupportedBrowser').isOn) { %>
@@ -194,6 +72,10 @@
       <script>
         <% include partials/featureDetection %>
       </script>
+    <% } %>
+
+    <% if (getFeatureFlag('frontier_snow_browserWarnings').isOn) { %>
+      <% include partials/browserWarnings %>
     <% } %>
   </body>
 </html>

--- a/packages/react-scripts/layout/views/partials/browserWarnings.ejs
+++ b/packages/react-scripts/layout/views/partials/browserWarnings.ejs
@@ -1,0 +1,121 @@
+    <%# No Cookies Warning %> 
+    <style>
+      .nocookies-container {
+        display: none;
+        flex-direction: column;
+        justify-content: center;
+        min-height: 100vh;
+        font-family: sans-serif;
+        max-width: 550px;
+        margin: 0 auto;
+      }
+
+      .nocookies-link {
+        display: inline-block;
+        border: 1px solid black;
+        color: black;
+        padding: 10px 20px;
+        text-decoration: none;
+        border-radius: 8px;
+      }
+
+      .nocookies-message {
+        margin-bottom: 10px;
+      }
+
+      .nocookies-last-message {
+        margin-bottom: 20px;
+      }
+
+      .nocookies-container svg {
+        display: flex;
+        align-self: center;
+        max-width: 72px;
+        height: auto;
+        margin-bottom: 20px;
+      }
+    </style>
+    <div id="nocookies-warning" class="nocookies-container">
+      <svg fill="none"><path stroke="#B5B8B8" stroke-dasharray="3 5" stroke-linecap="round" stroke-width="2" d="M28.92 1c56.58 65.5 0 73.14 0 50.32S68.5 31.5 52.68 80.022" style="stroke:#b5b8b8;stroke:color(display-p3 .7098 .7216 .7216);stroke-opacity:1"/><path fill="#83AF1D" d="M11.23 127.312s-1.742-17.022 7.845-27.404c9.586-10.383 26.711-10.204 26.711-10.204s1.742 17.022-7.844 27.405c-9.587 10.382-26.712 10.203-26.712 10.203Z" style="fill:#83af1d;fill:color(display-p3 .5137 .6863 .1137);fill-opacity:1"/><path fill="#A7C41A" fill-rule="evenodd" d="M48.621 86.664c.478.442.188 1.133 0 1.336l-30.516 32.374a.5.5 0 0 1-.733-.68L47.5 86.664c.188-.203.643-.442 1.121 0Z" clip-rule="evenodd" style="fill:#a7c41a;fill:color(display-p3 .6549 .7686 .102);fill-opacity:1"/><path stroke="#A7C41A" stroke-linecap="round" d="m16.708 114.07 6.517.148 1.795 5.411m6.666-6.37-2.295-5.383-6.625-2.145m14.56.714-1.795-5.411-7.071-1.12" style="stroke:#a7c41a;stroke:color(display-p3 .6549 .7686 .102);stroke-opacity:1"/></svg>
+      <h1><%- i18n('nocookies-title')%></h1>
+      <p class="nocookies-message"><%- i18n('nocookies-message')%></p>
+      <p class="nocookies-last-message"><%- i18n('nocookies-last-message')%></p>
+      <p>
+        <a href="https://www.whatismybrowser.com/guides/how-to-enable-cookies/" target="_blank" rel="noopener noreferrer" class="nocookies-link"><%- i18n('nocookies-link')%></a>
+      </p>
+    </div>
+
+    <%# Check if cookies are enabled %> 
+    <script>
+      (function() {
+        try {
+          document.cookie = "cookietest=1; SameSite=Lax; path=/";
+          var cookiesEnabled = document.cookie.indexOf("cookietest") !== -1;
+
+          if (cookiesEnabled) {
+            document.cookie = "cookietest=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+          }
+
+          if (!cookiesEnabled) {
+            var warningElement = document.querySelector(".nocookies-container");
+            if (warningElement) {
+              warningElement.style.display = "flex";
+            }
+          }
+        } catch (e) {
+          var warningElement = document.querySelector(".nocookies-container");
+          if (warningElement) {
+            warningElement.style.display = "flex";
+          }
+        }
+      })();
+    </script>
+
+    <%# No Script Warning %> 
+    <noscript>
+      <style>
+        .noscript-container {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          min-height: 100vh;
+          font-family: sans-serif;
+          max-width: 550px;
+          margin: 0 auto;
+        }
+
+        .noscript-link {
+          display: inline-block; 
+          border: 1px solid black;
+          color: black;
+          padding: 10px 20px;
+          text-decoration: none; 
+          border-radius: 8px; 
+        }
+
+        .noscript-message {
+          margin-bottom: 10px;
+        }
+
+        .noscript-last-message {
+          margin-bottom: 20px;
+        }
+
+        .noscript-container svg {
+          display: flex;
+          align-self: center;
+          max-width: 72px;
+          height: auto;
+          margin-bottom: 20px;
+        }
+      </style>
+      <div class="noscript-container">
+        <svg fill="none"><path stroke="#B5B8B8" stroke-dasharray="3 5" stroke-linecap="round" stroke-width="2" d="M28.92 1c56.58 65.5 0 73.14 0 50.32S68.5 31.5 52.68 80.022" style="stroke:#b5b8b8;stroke:color(display-p3 .7098 .7216 .7216);stroke-opacity:1"/><path fill="#83AF1D" d="M11.23 127.312s-1.742-17.022 7.845-27.404c9.586-10.383 26.711-10.204 26.711-10.204s1.742 17.022-7.844 27.405c-9.587 10.382-26.712 10.203-26.712 10.203Z" style="fill:#83af1d;fill:color(display-p3 .5137 .6863 .1137);fill-opacity:1"/><path fill="#A7C41A" fill-rule="evenodd" d="M48.621 86.664c.478.442.188 1.133 0 1.336l-30.516 32.374a.5.5 0 0 1-.733-.68L47.5 86.664c.188-.203.643-.442 1.121 0Z" clip-rule="evenodd" style="fill:#a7c41a;fill:color(display-p3 .6549 .7686 .102);fill-opacity:1"/><path stroke="#A7C41A" stroke-linecap="round" d="m16.708 114.07 6.517.148 1.795 5.411m6.666-6.37-2.295-5.383-6.625-2.145m14.56.714-1.795-5.411-7.071-1.12" style="stroke:#a7c41a;stroke:color(display-p3 .6549 .7686 .102);stroke-opacity:1"/></svg>
+        <h1><%- i18n('noscript-title')%></h1>
+        <p class="noscript-message"><%- i18n('noscript-message')%></p>
+        <p class="noscript-last-message"><%- i18n('noscript-last-message')%></p>
+        <p>
+          <a href="https://www.enable-javascript.com/" target="_blank" rel="noopener noreferrer" class="noscript-link"><%- i18n('noscript-link')%></a>
+        </p>
+      </div>
+    </noscript>

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.10.12",
+  "version": "8.11.0",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
> [!NOTE]
> This PR addresses the following Jira(s): [FRONTIER-1339](https://icseng.atlassian.net/browse/FRONTIER-1339)

Adding a `<noscript>` for javascript and a function and `<div>` for cookies in partials/browserWarnings.js to show users to enable them. 

<img width="1717" height="1076" alt="Screenshot 2025-11-11 at 11 19 27 AM" src="https://github.com/user-attachments/assets/94203245-508f-44f4-bfe3-bdb4a55012e6" />
<img width="1722" height="1076" alt="Screenshot 2025-11-11 at 11 19 48 AM" src="https://github.com/user-attachments/assets/edebb25e-f2a8-48d5-9548-5f115e820e1c" />


[FRONTIER-1339]: https://icseng.atlassian.net/browse/FRONTIER-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ