### PR TITLE
Add bodyParser middleware which is needed by auth-middleware

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,6 @@
+## 8.14.1
+- Add body-parser to proxy to support auth-middleware v3
+
 ## 8.14.0
 
 - Update to Node 24 and npm 11

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.14.0",
+  "version": "8.14.1",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/proxy/setupProxy.js
+++ b/packages/react-scripts/proxy/setupProxy.js
@@ -9,6 +9,7 @@ const setProxies = (app, customProxies = []) => {
   const cookieParser = require('cookie-parser')
   const base = require('connect-base')
   const metric = require('connect-metric')
+  const bodyParser = require('body-parser')
   const auth = require('@fs/auth-middleware')
   const resolver = require('./resolver')
   const proxyList = require('./proxies')
@@ -16,6 +17,7 @@ const setProxies = (app, customProxies = []) => {
 
   // middleware required for auth middleware
   app.use(metric())
+  app.use(bodyParser.json())
   app.use(base())
   app.use(resolver())
   app.use(cookieParser())


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Add bodyParser middleware which is needed by auth-middleware v3. @nicknielsen86 needs this for being able to test admin-mode code locally. He has tested this (copy and paste) in his app.
