### PR TITLE
fix(proxy): Move body-parser after proxy middleware to support streamed requests

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,6 @@
+## 8.14.2
+- Fix issue where body-parser was hanging up on streamed requests that were proxied
+
 ## 8.14.1
 - Add body-parser to proxy to support auth-middleware v3
 

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.14.1",
+  "version": "8.14.2",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/proxy/setupProxy.js
+++ b/packages/react-scripts/proxy/setupProxy.js
@@ -17,7 +17,6 @@ const setProxies = (app, customProxies = []) => {
 
   // middleware required for auth middleware
   app.use(metric())
-  app.use(bodyParser.json())
   app.use(base())
   app.use(resolver())
   app.use(cookieParser())
@@ -66,6 +65,13 @@ const setProxies = (app, customProxies = []) => {
   customProxies.forEach(config => setProxy(config))
   // set up all default proxies
   proxyList.forEach(proxyConfig => setProxy(proxyConfig))
+
+  // body-parser can't handled streamed requests made through the proxy, so we need to
+  // set it up after the proxy middleware to avoid interfering with the handling
+  // of requests.
+  app.use(bodyParser.json())
+  // In the future, consider matching snow's body-parser settings here:
+  // https://github.com/fs-webdev/snow/blob/bb74a5e613772d146c68e95543af5d6ef28d98c7/index.js#L471
 }
 
 module.exports = setProxies


### PR DESCRIPTION
RE: https://familysearch.slack.com/archives/C0FPL3ZL7/p1767812189924279

This PR fixes an issue where body-parser was hanging up on streamed requests that were proxied through the dev server.

The body-parser middleware was positioned before the proxy middleware, which caused it to attempt to parse the body of streamed requests. This resulted in those requests hanging.

Fun fact, we didn't see this as an issue in #405 because GET requests are generally small enough not to get streamed 🙃 So it wasn't until we tried proxying POST/PUT requests that we noticed anything (since they are _always_ streamed).

So I moved `body-parser.json()` to run after the proxy middleware setup. This allows streamed requests to be handled properly by the proxy without body-parser interfering with the request stream.
