### PR TITLE
Bump version for translations

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,6 @@
+## 8.14.3
+- Add translations for cookie and javascript warnings
+
 ## 8.14.2
 - Fix issue where body-parser was hanging up on streamed requests that were proxied
 

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.14.2",
+  "version": "8.14.3",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
We got back all the translations for the new JavaScript and Cookie pages, so in order for it to be consumable we need to bump the version of react-scripts. This is the story which is related to it: https://icseng.atlassian.net/browse/FRONTIER-3108

<img width="1575" height="486" alt="Screenshot 2026-01-14 at 10 15 34 AM" src="https://github.com/user-attachments/assets/36e23cf8-aa15-4456-bd6c-07b98bc46a56" />

