### PR TITLE
Fix body parser again

### DIFF
--- a/packages/react-scripts/proxy/setupProxy.js
+++ b/packages/react-scripts/proxy/setupProxy.js
@@ -16,10 +16,17 @@ const setProxies = (app, customProxies = []) => {
   const getDataLocalizationRouter = require('./getDataLocalizationRouter')
 
   // middleware required for auth middleware
+  // In the future consider mounting all at "/auth" to avoid any conflicts with proxy routes.
+  // Also, snow mounts auth-middleware locally as well so we should probably only use auth-middleware for local storybook and not locally running the full app.
   app.use(metric())
   app.use(base())
   app.use(resolver())
   app.use(cookieParser())
+  // body-parser can't handled streamed requests made through the proxy, so only mount it
+  // at the /auth path to avoid interfering with the handling of requests.
+  app.use('/auth', bodyParser.json())
+  // In the future, consider matching snow's body-parser settings here:
+  // https://github.com/fs-webdev/snow/blob/bb74a5e613772d146c68e95543af5d6ef28d98c7/index.js#L471
 
   // auth middleware
   auth('/auth', app)
@@ -66,12 +73,6 @@ const setProxies = (app, customProxies = []) => {
   // set up all default proxies
   proxyList.forEach(proxyConfig => setProxy(proxyConfig))
 
-  // body-parser can't handled streamed requests made through the proxy, so we need to
-  // set it up after the proxy middleware to avoid interfering with the handling
-  // of requests.
-  app.use(bodyParser.json())
-  // In the future, consider matching snow's body-parser settings here:
-  // https://github.com/fs-webdev/snow/blob/bb74a5e613772d146c68e95543af5d6ef28d98c7/index.js#L471
 }
 
 module.exports = setProxies


### PR DESCRIPTION
It has to be mounted before auth-middleware otherwise it doesn't work. Maybe the fix in pull #406 wasn't tested in a real locally running app with someone testing admin-mode? I've tested the current change in settings-react and it fixes the issue where a POST to "/auth/session" returns 500 (see https://familysearch.slack.com/archives/C0FPL3ZL7/p1769551211393939).

I also tested this in `discovery-kids` which is the one that broke with initially adding body-parser. I was able to get a random discovery service POST request to fail using just `app.use(bodyParser.json())` but it works fine with `app.use('/auth', bodyParser.json())`

Since this is a bug fix I'm proposing the smallest possible change here. However, I added some other comments about how we could improve this going forward:
1. Snow already mounts auth-middleware when running locally so I believe that react-scripts only needs to mount it for storybook. We could just have our `.storybook` template handle mounting it and get rid of handling it at all in react-scripts or conditionally mount it.
2. Auth-middleware specific middleware could also be mounted at "/auth" to prevent any interference with proxies.


<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
