### PR TITLE
Fix manifest URL generation for PWA apps with query parameter-based language codes

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,6 @@
+## 8.15.4
+- Strip query params from the app path before building the manifest.json in the layout template
+
 ## 8.15.3
 - Enhance conditional-test to ignore file exclusions when files are in the target folder
 

--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,6 +1,6 @@
 ## 8.15.6
 
-- Strip query params from the app path before building the manifest.json in the layout template
+- Exempting assets from having language query params from the app path before building the manifest.json in the layout template and putting the lang in the appropriate place for the url.
 
 ## 8.15.5
 

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -19,7 +19,12 @@
     <link rel="apple-touch-icon" href="<%= typeof logoHref !== 'undefined' ? logoHref : 'https://edge.fscdn.org/assets/components/hf/assets/img/tree-touch-icon-11024a277f1fda5735de5a9f0f4f75ca.png' %>" />
     
     <% if (typeof manifestJsonExists === 'undefined' || manifestJsonExists) { %>
-      <link rel="manifest" href="<%= typeof appPathOverride !== 'undefined' ? appPathOverride : appPath('') %>/manifest.json" type="application/manifest+json" crossorigin="use-credentials" />
+      <%
+        var manifestPath = typeof appPathOverride !== 'undefined' ? appPathOverride : appPath('');
+        // Strip query parameters for manifest path to avoid malformed URLs like /africa?lang=en/manifest.json
+        manifestPath = manifestPath.split('?')[0];
+      %>
+      <link rel="manifest" href="<%= manifestPath %>/manifest.json" type="application/manifest+json" crossorigin="use-credentials" />
     <% } %>
 
     <!-- Resource Hints -->

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -20,11 +20,12 @@
     
     <% if (typeof manifestJsonExists === 'undefined' || manifestJsonExists) { %>
       <%
-        var manifestPath = typeof appPathOverride !== 'undefined' ? appPathOverride : appPath('');
-        // Strip query parameters for manifest path to avoid malformed URLs like /africa?lang=en/manifest.json
-        manifestPath = manifestPath.split('?')[0];
+        // Construct manifest URL using URL constructor to extract relative path with query params
+        // e.g., http://localhost:5006/africa?lang=en/manifest.json becomes /africa/manifest.json?lang=en
+        var url = new URL(appPath('/manifest.json'));
+        var manifestUrl = url.pathname + url.search;
       %>
-      <link rel="manifest" href="<%= manifestPath %>/manifest.json" type="application/manifest+json" crossorigin="use-credentials" />
+      <link rel="manifest" href="<%= manifestUrl %>" type="application/manifest+json" crossorigin="use-credentials" />
     <% } %>
 
     <!-- Resource Hints -->

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -21,8 +21,11 @@
     <% if (typeof manifestJsonExists === 'undefined' || manifestJsonExists) { %>
       <%
         // Construct manifest URL using URL constructor to extract relative path with query params
-        // e.g., http://localhost:5006/africa?lang=en/manifest.json becomes /africa/manifest.json?lang=en
-        var url = new URL(appPath('/manifest.json'));
+        // Supports both normal app paths and appPathOverride for special routing scenarios
+        // e.g., http://localhost:5006/africa?lang=en becomes /africa/manifest.json?lang=en
+        var basePath = typeof appPathOverride !== 'undefined' ? appPathOverride : appPath('');
+        var url = new URL(basePath);
+        url.pathname = url.pathname.replace(/\/$/, '') + '/manifest.json';
         var manifestUrl = url.pathname + url.search;
       %>
       <link rel="manifest" href="<%= manifestUrl %>" type="application/manifest+json" crossorigin="use-credentials" />

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.15.3",
+  "version": "8.15.4",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
## The Problem
PWA apps using query parameter-based language codes (like `/africa?lang=en`) were generating malformed manifest URLs, causing browser console errors. The issue occurred because `appPath('')` returns the full app path including query parameters (e.g., `/africa?lang=en`), and the layout template was directly concatenating `/manifest.json`, resulting in invalid URLs like `/africa?lang=en/manifest.json` instead of `/africa/manifest.json`.                                    

## The Solution                                                                                                                                                           
We now strip query parameters from the app path before concatenating with `/manifest.json` in the layout template.                                                                                                        

Before:                                                                                                                                                               
```ejs                                                                                                                                                                
<link rel="manifest" href="<%= typeof appPathOverride !== 'undefined' ? appPathOverride : appPath('') %>/manifest.json" type="application/manifest+json" crossorigin="use-credentials" />
```

After:
```ejs
      <% if (typeof manifestJsonExists === 'undefined' || manifestJsonExists) { %>
      <%
        // Construct manifest URL using URL constructor to extract relative path with query params
        // Supports both normal app paths and appPathOverride for special routing scenarios
        // e.g., http://localhost:5006/africa?lang=en becomes /africa/manifest.json?lang=en
        var basePath = typeof appPathOverride !== 'undefined' ? appPathOverride : appPath('');
        var url = new URL(basePath);
        url.pathname = url.pathname.replace(/\/$/, '') + '/manifest.json';
        var manifestUrl = url.pathname + url.search;
      %>
      <link rel="manifest" href="<%= manifestUrl %>" type="application/manifest+json" crossorigin="use-credentials" />
```

**Impact** 
- Affected apps: PWA apps using query parameter-based language codes (currently: Africa, Pacific).
- Breaking change: No.
- Apps not affected: Apps using path-based language codes (like `/en/some-app`) are unaffected as they don't have query parameters in `appPath()`.

**IMPORTANT: Apps using this fix must also update their server.js to properly serve PWA assets and prevent redirects.**  Changes Required in client PWA App's `server.js`:
1. Define PWA assets (add after urlLookup definition):
 ```js
// PWA assets that need to be served directly and exempted from language redirects
const PWA_ASSETS = [
  'favicon.ico',
  'app-name-192x192.png',      // Replace with your app's icon names
  'app-name-512x512.png',
  'app-name-512x512-maskable.png',
  'app-name-screenshot1.png',
  'app-name-screenshot2.png',
  'app-name-screenshot3.png',
]
```

2. Exempt assets from language redirects (in snowConfig):                                                                                                             
```js                                                                                                                                                                        
pathsExemptedFromUrlLangs: ['/manifest.json', ...PWA_ASSETS.map((asset) => `/${asset}`)],
```

3. Add routes to serve PWA assets (in postRoute section, BEFORE the catch-all * route):
```js
// Serve manifest.json directly (ignore query parameters like ?lang=en)
snowApp.get('*/manifest.json', (_req, res) => {
  res.setHeader('Content-Type', 'application/manifest+json')
  res.sendFile(path.join(__dirname, 'public', 'manifest.json'))
})

// Serve PWA icon files directly from public directory
PWA_ASSETS.forEach((asset) => {
  snowApp.get(`*/${asset}`, (_req, res) => {
    res.sendFile(path.join(__dirname, 'public', asset))
  })
})
```
                                                                                                                                                                        
Why these changes are needed:                                                                                                                                         
- Without the exemptions, Snow redirects these requests to add `?lang=en`.
- Without the `server.js` routes, requests fall through to the catch-all SPA route, returning HTML instead of the actual files.                                                    
- Using a `PWA_ASSETS` constant (or similar) ensures the list is maintained in one place.

**Additional Context**
- Related to Snow's language code handling for PWA paths (configured in `FS_CLIENT_APP_LANG_QUERY_PARAM_PATHS` environment variable) in an app's `.env` file.
- Apps will also need server-side changes, described above, to prevent redirects and properly serve PWA assets (handled in individual app PRs).
- This fix ensures the HTML manifest link is correctly formatted; server-side configuration ensures the manifest is served without redirects.

**Update/Addendum**
The client app-specific changes above can be improved upon and automated for the app in Snow, as per Logan's comment below. That is captured in the Jira story: https://icseng.atlassian.net/browse/FRONTIER-3528