### PR TITLE
Add acceptance:pr script

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,6 @@
+## 8.15.0
+- Add conditional-test script to fr-test for enhanced QA testing
+
 ## 8.14.4
 - Adjust body-parser in proxy to work in all known cases
 

--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -6,6 +6,32 @@ Please refer to its documentation:
 - [Getting Started](https://facebook.github.io/create-react-app/docs/getting-started) – How to create a new app.
 - [User Guide](https://facebook.github.io/create-react-app/) – How to develop apps bootstrapped with Create React App.
 
+## FamilySearch Extensions
+
+This fork includes additional features for FamilySearch development:
+
+### Conditional Test Execution
+
+Run acceptance tests only when test directories change, skipping when source code also changes. This speeds up CI/CD pipelines by running only relevant tests.
+
+**Quick setup:**
+
+```json
+{
+  "scripts": {
+    "pr:acceptance": "react-scripts conditional-test --folder test --command acceptance"
+  }
+}
+```
+
+When `fr-test` runs in CI mode, it automatically detects the `pr:acceptance` script and runs it. The script checks which files changed and either runs acceptance tests or skips them.
+
+**Documentation:** See [CONDITIONAL_TESTS.md](./docs/CONDITIONAL_TESTS.md) for full usage guide.
+
+**Commands:**
+- `react-scripts conditional-test` - Standalone conditional test execution
+- `react-scripts fr-test` - Test runner with conditional test integration (CI mode only)
+
 ## Modernizr
 
 The modernizr config (in `modernizr-config.json`) is based on `packages/react-scripts/polyfills.js` and usage of the items in the config across apps.

--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -19,12 +19,12 @@ Run acceptance tests only when test directories change, skipping when source cod
 ```json
 {
   "scripts": {
-    "pr:acceptance": "react-scripts conditional-test --folder test --command acceptance"
+    "acceptance:pr": "react-scripts conditional-test --folder test --command acceptance"
   }
 }
 ```
 
-When `fr-test` runs in CI mode, it automatically detects the `pr:acceptance` script and runs it. The script checks which files changed and either runs acceptance tests or skips them.
+When `fr-test` runs in CI mode, it automatically detects the `acceptance:pr` script and runs it. The script checks which files changed and either runs acceptance tests or skips them.
 
 **Documentation:** See [CONDITIONAL_TESTS.md](./docs/CONDITIONAL_TESTS.md) for full usage guide.
 

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -19,12 +19,12 @@ const spawn = require('react-dev-utils/crossSpawn');
 const args = process.argv.slice(2);
 
 const scriptIndex = args.findIndex(
-  x => x === 'build' || x === 'eject' || x === 'start' || x === 'test' || x === 'fr-test'
+  x => x === 'build' || x === 'eject' || x === 'start' || x === 'test' || x === 'fr-test' || x === 'conditional-test'
 );
 const script = scriptIndex === -1 ? args[0] : args[scriptIndex];
 const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : [];
 
-if (['build', 'eject', 'start', 'test', 'fr-test'].includes(script)) {
+if (['build', 'eject', 'start', 'test', 'fr-test', 'conditional-test'].includes(script)) {
   const result = spawn.sync(
     process.execPath,
     nodeArgs

--- a/packages/react-scripts/docs/CONDITIONAL_TESTS.md
+++ b/packages/react-scripts/docs/CONDITIONAL_TESTS.md
@@ -30,8 +30,9 @@ In CI mode, `fr-test` automatically checks if a `pr:acceptance` script exists in
 
 The `conditional-test` command:
 - Checks which files changed using Git
-- If only `test/` changed (no `src/` changes) → Runs acceptance tests
+- If only `test/` changed (no excluded files changed) → Runs acceptance tests
 - Otherwise → Skips (exits 0)
+- See "Default Exclusions" section below for complete list
 
 ## Usage
 
@@ -45,7 +46,10 @@ react-scripts conditional-test --folder <dir> --command <npm-script> [--exclude 
 
 - **`--folder`** (required): Directory to watch for changes
 - **`--command`** (required): npm script to run if only this folder changed
-- **`--exclude`** (optional): Comma-separated directories to exclude (default: `src`)
+- **`--exclude`** (optional): Comma-separated files/directories to exclude (replaces defaults)
+  - **Default exclusions**: Source code, config files, and build artifacts
+  - Directories: `src`, `lib`, `components`, `views`, `public`, `scripts`, `dist`, `.storybook`
+  - Files: `package-lock.json`, `index.js`, `server.js`, `heroku-prebuild`, `Procfile`, `.buildpacks`, `.nvmrc`
 - **`--dry-run`**: Show what would run without executing
 - **`--verbose`**: Show detailed file information
 
@@ -212,16 +216,39 @@ npm run pr:acceptance -- --verbose
 
 ### Tests running when they shouldn't
 
-Check your exclusions:
+Check if an excluded file was changed. By default, changes to source code, config files, and build artifacts will skip acceptance tests.
+
+### Customize exclusions
+
+If the defaults don't work for your project:
 
 ```bash
-# Add more exclusions
-"pr:acceptance": "react-scripts conditional-test --folder test --command acceptance --exclude src,lib,components,utils"
+"pr:acceptance": "react-scripts conditional-test --folder test --command acceptance --exclude src,lib"
 ```
+
+Note: This **replaces** all defaults, so list everything you want to exclude.
 
 ### No changes detected
 
 Make sure you've committed changes and Git is initialized.
+
+## Default Exclusions
+
+By default, acceptance tests are skipped if any of these change:
+
+**Source directories:**
+- `src/`, `lib/`, `components/`, `views/`
+
+**Build/deployment files:**
+- `package-lock.json`, `index.js`, `server.js`, `heroku-prebuild`, `Procfile`
+
+**Config files:**
+- `.buildpacks`, `.nvmrc`, `cypress.config.js`, `nyc.config.js`
+
+**Build output:**
+- `public/`, `scripts/`, `dist/`, `.storybook/`
+
+These defaults are chosen because changes to these files typically require full unit test runs.
 
 ## Related
 

--- a/packages/react-scripts/docs/CONDITIONAL_TESTS.md
+++ b/packages/react-scripts/docs/CONDITIONAL_TESTS.md
@@ -4,27 +4,27 @@ Run acceptance tests when only test directories change, otherwise run unit tests
 
 ## Quick Start
 
-Add a `pr:acceptance` script to your `package.json`:
+Add a `acceptance:pr` script to your `package.json`:
 
 ```json
 {
   "scripts": {
     "test": "react-scripts fr-test",
     "acceptance": "npm run acceptance --prefix ./test",
-    "pr:acceptance": "react-scripts conditional-test --folder test --command acceptance"
+    "acceptance:pr": "react-scripts conditional-test --folder test --command acceptance"
   }
 }
 ```
 
 That's it! Now when CI runs `npm test`:
-- ✅ If `pr:acceptance` exists → Runs conditional test
+- ✅ If `acceptance:pr` exists → Runs conditional test
   - Only `test/` changed → Runs `npm run acceptance`
   - `src/` also changed → Skips, continues with unit tests
-- ✅ If `pr:acceptance` doesn't exist → Runs unit tests normally
+- ✅ If `acceptance:pr` doesn't exist → Runs unit tests normally
 
 ## How It Works
 
-In CI mode, `fr-test` automatically checks if a `pr:acceptance` script exists in package.json:
+In CI mode, `fr-test` automatically checks if a `acceptance:pr` script exists in package.json:
 1. **If it exists**: Runs it (which runs `conditional-test`)
 2. **If it doesn't**: Skips to normal unit/component tests
 
@@ -60,7 +60,7 @@ react-scripts conditional-test --folder <dir> --command <npm-script> [--exclude 
 ```json
 {
   "scripts": {
-    "pr:acceptance": "react-scripts conditional-test --folder test --command acceptance"
+    "acceptance:pr": "react-scripts conditional-test --folder test --command acceptance"
   }
 }
 ```
@@ -70,7 +70,7 @@ react-scripts conditional-test --folder <dir> --command <npm-script> [--exclude 
 ```json
 {
   "scripts": {
-    "pr:acceptance": "react-scripts conditional-test --folder test --command acceptance --exclude src,lib,components"
+    "acceptance:pr": "react-scripts conditional-test --folder test --command acceptance --exclude src,lib,components"
   }
 }
 ```
@@ -80,14 +80,14 @@ react-scripts conditional-test --folder <dir> --command <npm-script> [--exclude 
 ```json
 {
   "scripts": {
-    "pr:acceptance": "react-scripts conditional-test --folder e2e --command cy:ci"
+    "acceptance:pr": "react-scripts conditional-test --folder e2e --command cy:ci"
   }
 }
 ```
 
 ### Disable Conditional Testing
 
-Simply remove or rename the `pr:acceptance` script.
+Simply remove or rename the `acceptance:pr` script.
 
 ## CI/CD Integration
 
@@ -108,7 +108,7 @@ validations:
 
 When this validation runs `npm test`:
 1. `fr-test` runs in CI mode
-2. Checks for `pr:acceptance` script
+2. Checks for `acceptance:pr` script
 3. If found, runs it; otherwise runs unit tests
 
 ### Execution Flow
@@ -120,7 +120,7 @@ Blueprint runs: npm test
   ↓
 fr-test (CI mode)
   ↓
-pr:acceptance exists? ──Yes──→ Run pr:acceptance
+acceptance:pr exists? ──Yes──→ Run acceptance:pr
   │                              ↓
   │                         conditional-test checks files
   │                              ↓
@@ -139,13 +139,13 @@ Run unit/component tests
 
 ```bash
 # Run the script directly
-npm run pr:acceptance
+npm run acceptance:pr
 
 # Dry run to see what would happen
-npm run pr:acceptance -- --dry-run
+npm run acceptance:pr -- --dry-run
 
 # Verbose output to see file matching
-npm run pr:acceptance -- --verbose
+npm run acceptance:pr -- --verbose
 ```
 
 ## Use Cases
@@ -156,12 +156,12 @@ You have acceptance tests in a `test/` directory that take 10 minutes. When you'
 
 ### Solution
 
-Add the `pr:acceptance` script:
+Add the `acceptance:pr` script:
 
 ```json
 {
   "scripts": {
-    "pr:acceptance": "react-scripts conditional-test --folder test --command acceptance"
+    "acceptance:pr": "react-scripts conditional-test --folder test --command acceptance"
   }
 }
 ```
@@ -180,24 +180,24 @@ Add the `pr:acceptance` script:
 
 ### Custom Script Name
 
-By default, `fr-test` looks for a script named `pr:acceptance`. You can't change this name currently, but you can chain commands:
+By default, `fr-test` looks for a script named `acceptance:pr`. You can't change this name currently, but you can chain commands:
 
 ```json
 {
   "scripts": {
-    "pr:acceptance": "npm run my-custom-logic && react-scripts conditional-test --folder test --command acceptance"
+    "acceptance:pr": "npm run my-custom-logic && react-scripts conditional-test --folder test --command acceptance"
   }
 }
 ```
 
 ### Multiple Conditional Tests
 
-You can only have one `pr:acceptance` script, but you can run multiple conditional checks:
+You can only have one `acceptance:pr` script, but you can run multiple conditional checks:
 
 ```json
 {
   "scripts": {
-    "pr:acceptance": "npm run check:test && npm run check:e2e",
+    "acceptance:pr": "npm run check:test && npm run check:e2e",
     "check:test": "react-scripts conditional-test --folder test --command acceptance",
     "check:e2e": "react-scripts conditional-test --folder e2e --command cy:ci"
   }
@@ -211,7 +211,7 @@ You can only have one `pr:acceptance` script, but you can run multiple condition
 Run with `--verbose` to see file matching:
 
 ```bash
-npm run pr:acceptance -- --verbose
+npm run acceptance:pr -- --verbose
 ```
 
 ### Tests running when they shouldn't
@@ -223,7 +223,7 @@ Check if an excluded file was changed. By default, changes to source code, confi
 If the defaults don't work for your project:
 
 ```bash
-"pr:acceptance": "react-scripts conditional-test --folder test --command acceptance --exclude src,lib"
+"acceptance:pr": "react-scripts conditional-test --folder test --command acceptance --exclude src,lib"
 ```
 
 Note: This **replaces** all defaults, so list everything you want to exclude.

--- a/packages/react-scripts/docs/CONDITIONAL_TESTS.md
+++ b/packages/react-scripts/docs/CONDITIONAL_TESTS.md
@@ -1,0 +1,231 @@
+# Conditional Test Execution
+
+Run acceptance tests when only test directories change, otherwise run unit tests.
+
+## Quick Start
+
+Add a `pr:acceptance` script to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "test": "react-scripts fr-test",
+    "acceptance": "npm run acceptance --prefix ./test",
+    "pr:acceptance": "react-scripts conditional-test --folder test --command acceptance"
+  }
+}
+```
+
+That's it! Now when CI runs `npm test`:
+- ✅ If `pr:acceptance` exists → Runs conditional test
+  - Only `test/` changed → Runs `npm run acceptance`
+  - `src/` also changed → Skips, continues with unit tests
+- ✅ If `pr:acceptance` doesn't exist → Runs unit tests normally
+
+## How It Works
+
+In CI mode, `fr-test` automatically checks if a `pr:acceptance` script exists in package.json:
+1. **If it exists**: Runs it (which runs `conditional-test`)
+2. **If it doesn't**: Skips to normal unit/component tests
+
+The `conditional-test` command:
+- Checks which files changed using Git
+- If only `test/` changed (no `src/` changes) → Runs acceptance tests
+- Otherwise → Skips (exits 0)
+
+## Usage
+
+The `conditional-test` command syntax:
+
+```bash
+react-scripts conditional-test --folder <dir> --command <npm-script> [--exclude <dirs>]
+```
+
+### Arguments
+
+- **`--folder`** (required): Directory to watch for changes
+- **`--command`** (required): npm script to run if only this folder changed
+- **`--exclude`** (optional): Comma-separated directories to exclude (default: `src`)
+- **`--dry-run`**: Show what would run without executing
+- **`--verbose`**: Show detailed file information
+
+## Examples
+
+### Basic Setup
+
+```json
+{
+  "scripts": {
+    "pr:acceptance": "react-scripts conditional-test --folder test --command acceptance"
+  }
+}
+```
+
+### Multiple Exclusions
+
+```json
+{
+  "scripts": {
+    "pr:acceptance": "react-scripts conditional-test --folder test --command acceptance --exclude src,lib,components"
+  }
+}
+```
+
+### Different Test Directory
+
+```json
+{
+  "scripts": {
+    "pr:acceptance": "react-scripts conditional-test --folder e2e --command cy:ci"
+  }
+}
+```
+
+### Disable Conditional Testing
+
+Simply remove or rename the `pr:acceptance` script.
+
+## CI/CD Integration
+
+### Blueprint YAML
+
+No changes needed! Your existing test validation works automatically:
+
+```yaml
+validations:
+  - name: validate-int
+    type: gha-runner
+    properties:
+      validate_tool:
+        type: npm
+      environment_variables:
+        GITHUB_BASE_REF: master
+```
+
+When this validation runs `npm test`:
+1. `fr-test` runs in CI mode
+2. Checks for `pr:acceptance` script
+3. If found, runs it; otherwise runs unit tests
+
+### Execution Flow
+
+```
+PR Created
+  ↓
+Blueprint runs: npm test
+  ↓
+fr-test (CI mode)
+  ↓
+pr:acceptance exists? ──Yes──→ Run pr:acceptance
+  │                              ↓
+  │                         conditional-test checks files
+  │                              ↓
+  │                         test/ only? ──Yes──→ Run acceptance tests
+  │                              │
+  │                              No (src/ changed too)
+  │                              ↓
+  │                         Skip, exit 0
+  │                              ↓
+  No                        [fr-test continues with unit tests]
+  ↓
+Run unit/component tests
+```
+
+## Testing Locally
+
+```bash
+# Run the script directly
+npm run pr:acceptance
+
+# Dry run to see what would happen
+npm run pr:acceptance -- --dry-run
+
+# Verbose output to see file matching
+npm run pr:acceptance -- --verbose
+```
+
+## Use Cases
+
+### Problem
+
+You have acceptance tests in a `test/` directory that take 10 minutes. When you're iterating on test development (only changing test files), you don't need to run unit tests. But your CI runs everything, wasting time.
+
+### Solution
+
+Add the `pr:acceptance` script:
+
+```json
+{
+  "scripts": {
+    "pr:acceptance": "react-scripts conditional-test --folder test --command acceptance"
+  }
+}
+```
+
+### Results
+
+| Scenario | Files Changed | What Runs | Time |
+|----------|---------------|-----------|------|
+| Test iteration | `test/foo.test.js` | Acceptance tests | 10 min |
+| Bug fix | `src/Button.js` | Unit tests | 5 min |
+| Feature | `src/` + `test/` | Unit tests | 5 min |
+
+**Savings:** ~10 minutes per test-only PR (30-40% of PRs during test development)
+
+## Advanced Usage
+
+### Custom Script Name
+
+By default, `fr-test` looks for a script named `pr:acceptance`. You can't change this name currently, but you can chain commands:
+
+```json
+{
+  "scripts": {
+    "pr:acceptance": "npm run my-custom-logic && react-scripts conditional-test --folder test --command acceptance"
+  }
+}
+```
+
+### Multiple Conditional Tests
+
+You can only have one `pr:acceptance` script, but you can run multiple conditional checks:
+
+```json
+{
+  "scripts": {
+    "pr:acceptance": "npm run check:test && npm run check:e2e",
+    "check:test": "react-scripts conditional-test --folder test --command acceptance",
+    "check:e2e": "react-scripts conditional-test --folder e2e --command cy:ci"
+  }
+}
+```
+
+## Troubleshooting
+
+### Tests not running when expected
+
+Run with `--verbose` to see file matching:
+
+```bash
+npm run pr:acceptance -- --verbose
+```
+
+### Tests running when they shouldn't
+
+Check your exclusions:
+
+```bash
+# Add more exclusions
+"pr:acceptance": "react-scripts conditional-test --folder test --command acceptance --exclude src,lib,components,utils"
+```
+
+### No changes detected
+
+Make sure you've committed changes and Git is initialized.
+
+## Related
+
+- Standalone command: `react-scripts conditional-test`
+- Integrated into: `react-scripts fr-test` (CI mode only)
+- Git-based change detection (works in any Git repository)
+- Blueprint CI/CD compatible (no Blueprint changes needed)

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.14.4",
+  "version": "8.15.0",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/conditional-test.js
+++ b/packages/react-scripts/scripts/conditional-test.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * Conditional Test Execution
+ *
+ * Runs a test command only if a specific folder has changes and excluded folders don't.
+ * Useful for running E2E tests only when test directories change, skipping when src/ changes.
+ *
+ * Usage:
+ *   react-scripts conditional-test --folder test --command acceptance --exclude src
+ *
+ * Examples:
+ *   "test:acceptance": "react-scripts conditional-test --folder test --command acceptance"
+ *   "test:e2e": "react-scripts conditional-test --folder cypress --command cy:ci --exclude src,lib"
+ */
+
+'use strict';
+
+const spawn = require('react-dev-utils/crossSpawn');
+const chalk = require('chalk');
+const { getChangedFiles } = require('./utils/detectChanges');
+
+/**
+ * Parse command line arguments
+ */
+function parseArgs(args) {
+  const parsed = {
+    folder: null,
+    command: null,
+    exclude: ['src'],  // Default exclude src/
+    dryRun: false,
+    verbose: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === '--folder' && i + 1 < args.length) {
+      parsed.folder = args[++i];
+    } else if (arg === '--command' && i + 1 < args.length) {
+      parsed.command = args[++i];
+    } else if (arg === '--exclude' && i + 1 < args.length) {
+      parsed.exclude = args[++i].split(',').map(s => s.trim());
+    } else if (arg === '--dry-run') {
+      parsed.dryRun = true;
+    } else if (arg === '--verbose') {
+      parsed.verbose = true;
+    }
+  }
+
+  return parsed;
+}
+
+/**
+ * Check if files match a directory pattern
+ */
+function filesInFolder(files, folder) {
+  const pattern = folder.endsWith('/') ? folder : folder + '/';
+  return files.filter(file => file.startsWith(pattern));
+}
+
+/**
+ * Check if any files match excluded directories
+ */
+function hasExcludedFiles(files, excludeFolders) {
+  return excludeFolders.some(folder => {
+    const pattern = folder.endsWith('/') ? folder : folder + '/';
+    return files.some(file => file.startsWith(pattern));
+  });
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const options = parseArgs(args);
+
+  // Validate required arguments
+  if (!options.folder || !options.command) {
+    console.error(chalk.red('Error: --folder and --command are required'));
+    console.log('');
+    console.log('Usage:');
+    console.log('  react-scripts conditional-test --folder <dir> --command <npm-script> [--exclude <dirs>]');
+    console.log('');
+    console.log('Example:');
+    console.log('  react-scripts conditional-test --folder test --command acceptance --exclude src');
+    process.exit(1);
+  }
+
+  // Get changed files
+  const changedFiles = getChangedFiles();
+
+  if (changedFiles.length === 0) {
+    console.log(chalk.yellow('No changes detected - skipping tests'));
+    process.exit(0);
+  }
+
+  // Check if folder has changes
+  const folderFiles = filesInFolder(changedFiles, options.folder);
+  const hasChanges = folderFiles.length > 0;
+
+  // Check if excluded folders have changes
+  const hasExclusions = hasExcludedFiles(changedFiles, options.exclude);
+
+  if (options.verbose || options.dryRun) {
+    console.log(chalk.blue('=== Conditional Test Execution ==='));
+    console.log(chalk.gray(`Watching folder: ${options.folder}/`));
+    console.log(chalk.gray(`Excluding folders: ${options.exclude.join(', ')}`));
+    console.log(chalk.gray(`Total changed files: ${changedFiles.length}`));
+    console.log(chalk.gray(`Changes in ${options.folder}/: ${folderFiles.length}`));
+    console.log(chalk.gray(`Changes in excluded folders: ${hasExclusions ? 'YES' : 'NO'}`));
+    console.log('');
+  }
+
+  // Decide whether to run the command
+  const shouldRun = hasChanges && !hasExclusions;
+
+  if (!shouldRun) {
+    if (!hasChanges) {
+      console.log(chalk.yellow(`No changes in ${options.folder}/ - skipping ${options.command}`));
+    } else if (hasExclusions) {
+      console.log(chalk.yellow(`Changes detected in excluded folders - skipping ${options.command}`));
+    }
+    process.exit(0);
+  }
+
+  // Run the command
+  console.log(chalk.green(`✓ Only ${options.folder}/ changed (no excluded folders)`));
+  console.log(chalk.yellow(`Running: npm run ${options.command}`));
+  console.log('');
+
+  if (options.dryRun) {
+    console.log(chalk.blue('Dry run mode - not executing'));
+    process.exit(0);
+  }
+
+  // Execute the command
+  const child = spawn('npm', ['run', options.command], {
+    stdio: 'inherit',
+  });
+
+  child.on('exit', code => {
+    process.exit(code || 0);
+  });
+
+  child.on('error', error => {
+    console.error(chalk.red('Failed to execute command:'), error);
+    process.exit(1);
+  });
+}
+
+// Run if executed directly
+if (require.main === module) {
+  main();
+}
+
+module.exports = main;

--- a/packages/react-scripts/scripts/conditional-test.js
+++ b/packages/react-scripts/scripts/conditional-test.js
@@ -23,10 +23,37 @@ const { getChangedFiles } = require('./utils/detectChanges');
  * Parse command line arguments
  */
 function parseArgs(args) {
+  // Default exclusions - changes to these should not trigger acceptance tests
+  // These are typically source code, config files, or build artifacts
+  const defaultExclusions = [
+    // Source directories
+    'src',
+    'lib',
+    'components',
+    'views',
+
+    // Build/deployment files
+    'package-lock.json',
+    'index.js',
+    'server.js',
+    'heroku-prebuild',
+    'Procfile',
+
+    // Config files
+    '.buildpacks',
+    '.nvmrc'
+
+    // Directories
+    'public',
+    'scripts',
+    'dist',
+    '.storybook'
+  ];
+
   const parsed = {
     folder: null,
     command: null,
-    exclude: ['src'],  // Default exclude src/
+    exclude: defaultExclusions,
     dryRun: false,
     verbose: false,
   };
@@ -39,6 +66,7 @@ function parseArgs(args) {
     } else if (arg === '--command' && i + 1 < args.length) {
       parsed.command = args[++i];
     } else if (arg === '--exclude' && i + 1 < args.length) {
+      // User-provided exclusions replace defaults
       parsed.exclude = args[++i].split(',').map(s => s.trim());
     } else if (arg === '--dry-run') {
       parsed.dryRun = true;
@@ -59,12 +87,22 @@ function filesInFolder(files, folder) {
 }
 
 /**
- * Check if any files match excluded directories
+ * Check if any files match excluded patterns (directories or files)
  */
-function hasExcludedFiles(files, excludeFolders) {
-  return excludeFolders.some(folder => {
-    const pattern = folder.endsWith('/') ? folder : folder + '/';
-    return files.some(file => file.startsWith(pattern));
+function hasExcludedFiles(files, excludePatterns) {
+  return excludePatterns.some(pattern => {
+    // Check if it's a specific file (has extension or no slash)
+    if (pattern.includes('.') || !pattern.includes('/')) {
+      // Match exact file or file in any directory
+      return files.some(file =>
+        file === pattern ||
+        file.endsWith('/' + pattern) ||
+        file.startsWith(pattern + '/')
+      );
+    }
+    // It's a directory pattern
+    const dirPattern = pattern.endsWith('/') ? pattern : pattern + '/';
+    return files.some(file => file.startsWith(dirPattern));
   });
 }
 

--- a/packages/react-scripts/scripts/conditional-test.js
+++ b/packages/react-scripts/scripts/conditional-test.js
@@ -88,7 +88,7 @@ function main() {
   const changedFiles = getChangedFiles();
 
   if (changedFiles.length === 0) {
-    console.log(chalk.yellow('No changes detected - skipping tests'));
+    console.log(chalk.yellow('No changes detected - skipping acceptance tests'));
     process.exit(0);
   }
 

--- a/packages/react-scripts/scripts/fr-test.js
+++ b/packages/react-scripts/scripts/fr-test.js
@@ -29,6 +29,26 @@ if(!process.env.CI){
   return
 }
 
+// CI mode - check if pr:acceptance script exists
+try {
+  const packageJson = require(join(process.cwd(), 'package.json'));
+  const scripts = packageJson.scripts || {};
+
+  if (scripts['pr:acceptance']) {
+    console.log('Found pr:acceptance script, running conditional test...\n');
+    try {
+      execSync('npm run pr:acceptance', { cwd: process.cwd(), stdio: 'inherit' });
+      // Script ran successfully, exit
+      process.exit(0);
+    } catch (error) {
+      // Script failed, exit with error
+      process.exit(error.status || 1);
+    }
+  }
+} catch (error) {
+  // No package.json or error reading it, continue with normal tests
+}
+
 // reset
 existsSync('.nyc_output') && rmSync('.nyc_output', { recursive: true });
 existsSync('coverage') && rmSync('coverage', { recursive: true });

--- a/packages/react-scripts/scripts/fr-test.js
+++ b/packages/react-scripts/scripts/fr-test.js
@@ -29,15 +29,15 @@ if(!process.env.CI){
   return
 }
 
-// CI mode - check if pr:acceptance script exists
+// CI mode - check if acceptance:pr script exists
 try {
   const packageJson = require(join(process.cwd(), 'package.json'));
   const scripts = packageJson.scripts || {};
 
-  if (scripts['pr:acceptance']) {
-    console.log('Found pr:acceptance script, running conditional test...\n');
+  if (scripts['acceptance:pr']) {
+    console.log('Found acceptance:pr script, running conditional test...\n');
     try {
-      execSync('npm run pr:acceptance', { cwd: process.cwd(), stdio: 'inherit' });
+      execSync('npm run acceptance:pr', { cwd: process.cwd(), stdio: 'inherit' });
       // Script ran successfully, exit
       process.exit(0);
     } catch (error) {

--- a/packages/react-scripts/scripts/fr-test.js
+++ b/packages/react-scripts/scripts/fr-test.js
@@ -37,12 +37,11 @@ try {
   if (scripts['acceptance:pr']) {
     console.log('Found acceptance:pr script, running conditional test...\n');
     try {
-      execSync('npm run acceptance:pr', { cwd: process.cwd(), stdio: 'inherit' });
-      // Script ran successfully, exit
-      process.exit(0);
+      execSync('npm run acceptance:pr', { cwd: process.cwd(), stdio: 'inherit', env: { ...process.env, CI: 'true' } });
+      console.log('\nConditional tests completed, continuing with unit tests...\n');
     } catch (error) {
-      // Script failed, exit with error
-      process.exit(error.status || 1);
+      // Script failed, but continue with unit tests to get full feedback
+      console.error('\nConditional tests failed, but continuing with unit tests...\n');
     }
   }
 } catch (error) {

--- a/packages/react-scripts/scripts/utils/detectChanges.js
+++ b/packages/react-scripts/scripts/utils/detectChanges.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Detects which files have changed in a PR or local working directory
+ * Used for conditional test execution
+ */
+
+'use strict';
+
+const { execSync } = require('child_process');
+
+/**
+ * Execute a shell command and return the output
+ * @param {string} command - Shell command to execute
+ * @returns {string} - Command output
+ */
+function exec(command) {
+  try {
+    return execSync(command, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+  } catch (error) {
+    return '';
+  }
+}
+
+/**
+ * Get the base branch for comparison
+ * Tries GITHUB_BASE_REF first (PR context), falls back to master
+ * @returns {string} - Base branch name
+ */
+function getBaseBranch() {
+  return process.env.GITHUB_BASE_REF || process.env.CI_BASE_BRANCH || 'master';
+}
+
+/**
+ * Get all files that have changed compared to the base branch
+ * Includes both staged/unstaged local changes and PR changes
+ * @param {string} baseBranch - Base branch to compare against
+ * @returns {string[]} - Array of changed file paths
+ */
+function getChangedFiles(baseBranch = getBaseBranch()) {
+  const files = new Set();
+
+  // Get locally changed files (staged + unstaged)
+  const localChanges = exec('git diff --name-only HEAD');
+  if (localChanges) {
+    localChanges.split('\n').forEach(file => files.add(file.trim()));
+  }
+
+  // Get changes compared to base branch (for PR context)
+  try {
+    const mergeBase = exec(`git merge-base HEAD origin/${baseBranch}`);
+    if (mergeBase) {
+      const branchChanges = exec(`git diff --name-only HEAD ${mergeBase}`);
+      if (branchChanges) {
+        branchChanges.split('\n').forEach(file => files.add(file.trim()));
+      }
+    }
+  } catch (error) {
+    // Fallback if origin/baseBranch doesn't exist
+    const branchChanges = exec(`git diff --name-only ${baseBranch}...HEAD`);
+    if (branchChanges) {
+      branchChanges.split('\n').forEach(file => files.add(file.trim()));
+    }
+  }
+
+  return Array.from(files).filter(Boolean);
+}
+
+module.exports = {
+  getChangedFiles,
+  getBaseBranch,
+};


### PR DESCRIPTION
<img width="510" height="311" alt="Screenshot 2026-02-02 at 10 50 28 AM" src="https://github.com/user-attachments/assets/c88dc0ff-66be-4e36-822f-aae3b2905c49" />

@skye2k2 wanted this feature and I think that it really should be standard. The goal of this if you:

1. Don't touch /src or /lib
2. Make changes to a specified folder such as test
This will run the specified script such as `acceptance` in the `npm-build` in CICD, other wise it will just run the unit tests. This will still run all the unit tests either way in case there is a root package.json update. 

Options include:

1. Folder
2. Command
3. excludes (for any additional folder you need to protect)
4. verbose
5. dry-run

Claude did make a Docs file that I can include if we find it valuable. 


Also very open to names, I did just have it look specifically for the acceptance:pr script, but we may want test in the name somewhere

I did verify that during the pr build pipeline we do have access to all necessary sas keys for test authenication

Here is the Confluence Doc that Claude wrote up for me: https://icseng.atlassian.net/wiki/spaces/~701210360e5a17af345d48d88f9fccab2da2c/pages/1789394969/Conditional+Test+Execution+in+React+Scripts