### PR TITLE
Ignore exclusions inside target folder

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,6 @@
+## 8.15.3
+- Enhance conditional-test to ignore file exclusions when files are in the target folder
+
 ## 8.15.2
 - Adjust fr-test to only run conditional-test while in GHA
 

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.15.2",
+  "version": "8.15.3",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/conditional-test.js
+++ b/packages/react-scripts/scripts/conditional-test.js
@@ -5,6 +5,10 @@
  * Runs a test command only if a specific folder has changes and excluded folders don't.
  * Useful for running E2E tests only when test directories change, skipping when src/ changes.
  *
+ * Important: Exclusions are ignored for files within the target folder. This means if you
+ * change test/package-lock.json, tests will run even though package-lock.json is normally
+ * excluded. Only changes to excluded files OUTSIDE the target folder will skip tests.
+ *
  * Usage:
  *   react-scripts conditional-test --folder test --command acceptance --exclude src
  *
@@ -134,16 +138,19 @@ function main() {
   const folderFiles = filesInFolder(changedFiles, options.folder);
   const hasChanges = folderFiles.length > 0;
 
-  // Check if excluded folders have changes
-  const hasExclusions = hasExcludedFiles(changedFiles, options.exclude);
+  // Check if excluded folders have changes (but ignore exclusions in target folder)
+  // This allows test/package-lock.json to trigger tests even though package-lock.json is excluded
+  const filesOutsideTargetFolder = changedFiles.filter(file => !folderFiles.includes(file));
+  const hasExclusions = hasExcludedFiles(filesOutsideTargetFolder, options.exclude);
 
   if (options.verbose || options.dryRun) {
     console.log(chalk.blue('=== Conditional Test Execution ==='));
     console.log(chalk.gray(`Watching folder: ${options.folder}/`));
-    console.log(chalk.gray(`Excluding folders: ${options.exclude.join(', ')}`));
+    console.log(chalk.gray(`Excluding patterns: ${options.exclude.join(', ')}`));
     console.log(chalk.gray(`Total changed files: ${changedFiles.length}`));
     console.log(chalk.gray(`Changes in ${options.folder}/: ${folderFiles.length}`));
-    console.log(chalk.gray(`Changes in excluded folders: ${hasExclusions ? 'YES' : 'NO'}`));
+    console.log(chalk.gray(`Changes outside ${options.folder}/: ${filesOutsideTargetFolder.length}`));
+    console.log(chalk.gray(`Excluded changes outside target folder: ${hasExclusions ? 'YES' : 'NO'}`));
     console.log('');
   }
 


### PR DESCRIPTION
When I was testing this, I realized that we exclude package-lock.json from running the acceptance tests by default which is great. However, if your target folder (like /test/) has a package-lock that also prevents the acceptance tests from running which is not great since we want to validate dependency updates are working. 

https://icseng.atlassian.net/browse/FRONTIER-3422