### PR TITLE
Prevent try catch from catching all errors

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,6 @@
+## 8.15.4
+- Fix fr-test to fail immediately when acceptance tests fail (consistent with Cypress and Jest behavior)
+
 ## 8.15.3
 - Enhance conditional-test to ignore file exclusions when files are in the target folder
 

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.15.3",
+  "version": "8.15.4",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/fr-test.js
+++ b/packages/react-scripts/scripts/fr-test.js
@@ -69,7 +69,6 @@ if(jestTestsExist){
 // If both types exist, merge coverage reports
 if(cypressTestsExist && jestTestsExist){
   mergeReports()
-
   // if only cypress tests exist, move the coverage reports to the coverage directory
 } else if(cypressTestsExist){
   renameSync('coverage-cypress', 'coverage');

--- a/packages/react-scripts/scripts/fr-test.js
+++ b/packages/react-scripts/scripts/fr-test.js
@@ -31,22 +31,17 @@ if(!process.env.CI){
 
 // GitHub Actions mode - check if acceptance:pr script exists
 if (process.env.GITHUB_ACTIONS) {
+  let packageJson;
   try {
-    const packageJson = require(join(process.cwd(), 'package.json'));
-    const scripts = packageJson.scripts || {};
-
-    if (scripts['acceptance:pr']) {
-      console.log('Found acceptance:pr script, running conditional test...\n');
-      try {
-        execSync('npm run acceptance:pr', { cwd: process.cwd(), stdio: 'inherit', env: { ...process.env, GITHUB_ACTIONS: 'true' } });
-        console.log('\nConditional tests completed, continuing with unit tests...\n');
-      } catch (error) {
-        // Script failed, but continue with unit tests to get full feedback
-        console.error('\nConditional tests failed, but continuing with unit tests...\n');
-      }
-    }
+    packageJson = require(join(process.cwd(), 'package.json'));
   } catch (error) {
     // No package.json or error reading it, continue with normal tests
+    packageJson = null;
+  }
+
+  if (packageJson && packageJson.scripts && packageJson.scripts['acceptance:pr']) {
+    console.log('Found acceptance:pr script, running conditional test...\n');
+    execSync('npm run acceptance:pr', { cwd: process.cwd(), stdio: 'inherit', env: { ...process.env, GITHUB_ACTIONS: 'true' } });
   }
 }
 
@@ -74,7 +69,7 @@ if(jestTestsExist){
 // If both types exist, merge coverage reports
 if(cypressTestsExist && jestTestsExist){
   mergeReports()
-  
+
   // if only cypress tests exist, move the coverage reports to the coverage directory
 } else if(cypressTestsExist){
   renameSync('coverage-cypress', 'coverage');


### PR DESCRIPTION
Problem: 
<img width="1667" height="560" alt="Screenshot 2026-02-13 at 12 29 20 PM" src="https://github.com/user-attachments/assets/6561deb5-d701-457d-bb2e-3a693f5d8f98" />
The tests failed and we still had a green build

Solution:
Instead of putting everything in a try, catch which was catching a little bit too much. I moved the actual running of the tests outside of it, so it should fail very similarly to how the cypress and jest tests do where it won't continue on, pass go, and collect 200 dollars. 
<img width="835" height="382" alt="Screenshot 2026-02-13 at 12 22 55 PM" src="https://github.com/user-attachments/assets/d275bd06-2da2-4d11-bbc4-667c58f97b97" />
