### PR TITLE
[react-scripts: start] Default TSC_COMPILE_ON_ERROR to true for local dev

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,7 @@
+## 8.15.8
+
+- Default TSC_COMPILE_ON_ERROR to true in the dev server so TypeScript errors are non-blocking during local development
+
 ## 8.15.7
 
 - Fix coalesceLocales not traversing from `.js` files into `.tsx` files, causing translations from packages only reachable through `.tsx` imports to be silently missing from the coalesced output

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.15.7",
+  "version": "8.15.8",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -11,6 +11,8 @@
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = 'development';
 process.env.NODE_ENV = 'development';
+// Default to treating TypeScript errors as warnings (non-blocking) during local development
+process.env.TSC_COMPILE_ON_ERROR = process.env.TSC_COMPILE_ON_ERROR ?? 'true';
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will


### PR DESCRIPTION
Prevents TypeScript type errors from blocking the dev server during local development, while still allowing CI/build environments to override the behavior by setting TSC_COMPILE_ON_ERROR explicitly.

Tested in tree-person-r9 by making a TS error and seeing it fail without the flag and then seeing it not show the error on the webpage with the flag default in this pr.

This will make it so we don't need to include TSC_COMPILE_ON_ERROR for the start script in each app.