### PR TITLE
Update CI mode script to allow passing in args

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,12 @@
+## 8.16.0
+
+- Enable Jest CLI argument passing through test wrapper scripts (fr-test and conditional-test)
+  - Developers can now pass Jest flags directly: `npm test -- --maxWorkers=2`
+  - Support for test filtering: `npm test -- --testNamePattern="login"`
+  - Support for file/directory paths: `npm test -- src/features/`
+  - Fixed argument forwarding in conditional-test to support all Jest CLI options
+  - Switched from string interpolation to array-based spawn.sync for safer argument handling
+
 ## 8.15.9
 
 - Move nocookies warning to Shadow DOM to prevent WebDriver detection

--- a/README-FRONTIER.md
+++ b/README-FRONTIER.md
@@ -25,6 +25,70 @@ If you have cloned this repo and made changes locally and want to test them befo
 
 Before running `npm link`, run `npm publish --dry-run` to ensure modernizr.js is added in `./packages/react-scripts/layout`
 
+## Test Commands - CLI Arguments
+
+The `react-scripts fr-test` and `react-scripts conditional-test` commands support passing arguments to Jest and Cypress.
+
+### fr-test - Flexible Jest/Cypress Test Runner
+
+Basic setup in package.json:
+```json
+{
+  "test": "react-scripts fr-test"
+}
+```
+
+CLI usage examples:
+```bash
+# Control Jest parallelization
+npm run test -- --maxWorkers=2
+
+# Run tests in a specific directory
+npm run test -- src/features/
+
+# Run a single test file
+npm run test -- Auth.test.js
+
+# Filter tests by name pattern
+npm run test -- --testNamePattern="login"
+
+# Combine multiple arguments
+npm run test -- src/features/ --maxWorkers=1 --testNamePattern="auth"
+
+# Watch mode (dev only, not in CI)
+npm run test -- --watch
+
+# Run in CI mode (coverage, no watch)
+CI=true npm run test
+```
+
+### conditional-test - Run Tests Only on Relevant Changes
+
+Example setup:
+```json
+{
+  "test:acceptance": "react-scripts conditional-test --folder test --command acceptance"
+}
+```
+
+CLI usage with arguments:
+```bash
+# Run acceptance tests only if test/ folder changed
+npm run test:acceptance
+
+# With Jest arguments
+npm run test:acceptance -- --maxWorkers=2
+
+# Filter by test name
+npm run test:acceptance -- --testNamePattern="api"
+
+# Dry run to see what would execute
+npm run test:acceptance -- --dry-run
+
+# Verbose mode to see change detection details
+npm run test:acceptance -- --verbose
+```
+
 ## Development and Cutting a Release
 
 - All development will be done from the frontierMaster branch

--- a/package-lock.json
+++ b/package-lock.json
@@ -43779,7 +43779,7 @@
     },
     "packages/react-scripts": {
       "name": "@fs/react-scripts",
-      "version": "8.15.7",
+      "version": "8.16.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.15.9",
+  "version": "8.15.10",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.15.10",
+  "version": "8.16.0",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {

--- a/packages/react-scripts/scripts/conditional-test.js
+++ b/packages/react-scripts/scripts/conditional-test.js
@@ -96,6 +96,11 @@ function parseArgs(args) {
       break;
     } else {
       // Unrecognized arguments are collected as test arguments to forward
+      // Warn if argument looks like a flag (starts with --) in case of typo
+      if (arg.startsWith('--')) {
+        console.warn(chalk.yellow(`⚠️  Warning: Unrecognized flag "${arg}" will be forwarded to the test command.`));
+        console.warn(chalk.yellow(`   Valid conditional-test flags: ${recognizedFlags.join(', ')}`));
+      }
       parsed.testArgs.push(arg);
     }
   }
@@ -207,6 +212,17 @@ function main() {
   const result = spawn.sync('npm', npmArgs, {
     stdio: 'inherit',
   });
+
+  if (result.error) {
+    console.error(chalk.red(`Failed to execute: npm ${npmArgs.join(' ')}`));
+    console.error(chalk.red(result.error.message));
+    process.exit(1);
+  }
+
+  if (result.signal) {
+    console.error(chalk.red(`npm was killed by signal: ${result.signal}`));
+    process.exit(1);
+  }
 
   process.exit(result.status || 0);
 }

--- a/packages/react-scripts/scripts/conditional-test.js
+++ b/packages/react-scripts/scripts/conditional-test.js
@@ -9,12 +9,23 @@
  * change test/package-lock.json, tests will run even though package-lock.json is normally
  * excluded. Only changes to excluded files OUTSIDE the target folder will skip tests.
  *
- * Usage:
- *   react-scripts conditional-test --folder test --command acceptance --exclude src
+ * Conditional Test Flags:
+ *   --folder <dir>              Target folder to watch for changes (required)
+ *   --command <npm-script>      NPM script to run if changes detected (required)
+ *   --exclude <dirs>            Comma-separated folders to exclude (optional, has defaults)
+ *   --dry-run                   Show what would run without executing
+ *   --verbose                   Show detailed change detection info
+ *
+ * Test Arguments (forwarded to the npm script):
+ *   Arguments after -- are passed to the npm script being called
+ *   npm run test:acceptance -- --maxWorkers=2       Forward Jest flags
+ *   npm run test:acceptance -- src/features/        Run tests in specific directory
+ *   npm run test:acceptance -- --testNamePattern="login"  Filter by test name
  *
  * Examples:
  *   "test:acceptance": "react-scripts conditional-test --folder test --command acceptance"
  *   "test:e2e": "react-scripts conditional-test --folder cypress --command cy:ci --exclude src,lib"
+ *   "test:acceptance": "npm run test:acceptance -- --maxWorkers=2"  (forward args to npm script)
  */
 
 'use strict';
@@ -60,7 +71,10 @@ function parseArgs(args) {
     exclude: defaultExclusions,
     dryRun: false,
     verbose: false,
+    testArgs: [], // Arguments to forward to the test command
   };
+
+  const recognizedFlags = ['--folder', '--command', '--exclude', '--dry-run', '--verbose'];
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -76,6 +90,13 @@ function parseArgs(args) {
       parsed.dryRun = true;
     } else if (arg === '--verbose') {
       parsed.verbose = true;
+    } else if (arg === '--') {
+      // Everything after -- is test arguments
+      parsed.testArgs = args.slice(i + 1);
+      break;
+    } else {
+      // Unrecognized arguments are collected as test arguments to forward
+      parsed.testArgs.push(arg);
     }
   }
 
@@ -176,19 +197,18 @@ function main() {
     process.exit(0);
   }
 
-  // Execute the command
-  const child = spawn('npm', ['run', options.command], {
+  // Execute the command, forwarding any test arguments via --
+  const npmArgs = ['run', options.command];
+  if (options.testArgs.length > 0) {
+    npmArgs.push('--');
+    npmArgs.push(...options.testArgs);
+  }
+
+  const result = spawn.sync('npm', npmArgs, {
     stdio: 'inherit',
   });
 
-  child.on('exit', code => {
-    process.exit(code || 0);
-  });
-
-  child.on('error', error => {
-    console.error(chalk.red('Failed to execute command:'), error);
-    process.exit(1);
-  });
+  process.exit(result.status || 0);
 }
 
 // Run if executed directly

--- a/packages/react-scripts/scripts/fr-test.js
+++ b/packages/react-scripts/scripts/fr-test.js
@@ -1,6 +1,25 @@
+/**
+ * FamilySearch Test Runner
+ *
+ * Runs Jest and/or Cypress component tests depending on what exists in src/
+ * - Automatically detects .test.* and .cy.* files
+ * - Runs both test types if present
+ * - Merges coverage reports from Jest and Cypress
+ *
+ * CLI Arguments (forwarded to Jest/Cypress):
+ *   npm run test -- --maxWorkers=2              Control parallelization
+ *   npm run test -- src/features/                Run tests in a specific directory
+ *   npm run test -- Auth.test.js                 Run a single test file
+ *   npm run test -- --testNamePattern="login"   Filter tests by name pattern
+ *   npm run test -- --watch                      Watch mode (dev only)
+ *
+ * Environment Variables:
+ *   CI=true          Run in CI mode (with coverage, no watch)
+ */
 'use strict'
 const {renameSync, existsSync, rmSync, mkdirSync, copyFileSync} = require('fs');
 const { execSync } = require('child_process')
+const spawn = require('react-dev-utils/crossSpawn');
 const glob = require('fast-glob')
 const { join } = require('path')
 
@@ -24,9 +43,9 @@ const mergeReports = ()=>{
 }
 // dev ran npm test
 if(!process.env.CI){
-  const args = process.argv.slice(2).join(' ')
-  execSync(`react-scripts test ${args}`, { stdio: 'inherit' })
-  return
+  const args = process.argv.slice(2);
+  const result = spawn.sync('react-scripts', ['test'].concat(args), { stdio: 'inherit' })
+  process.exit(result.status || 0)
 }
 
 // GitHub Actions mode - check if acceptance:pr script exists
@@ -63,8 +82,11 @@ if(cypressTestsExist){
 
 if(jestTestsExist){
   console.log('RUNNING JEST TESTS')
-  const args = process.argv.slice(2).join(' ')
-  execSync(`react-scripts test --coverage --colors ${args}`, { cwd: process.cwd(), stdio: 'inherit' })
+  const args = process.argv.slice(2);
+  const result = spawn.sync('react-scripts', ['test', '--coverage', '--colors'].concat(args), { cwd: process.cwd(), stdio: 'inherit' })
+  if(result.status) {
+    process.exit(result.status)
+  }
 }
 
 // If both types exist, merge coverage reports

--- a/packages/react-scripts/scripts/fr-test.js
+++ b/packages/react-scripts/scripts/fr-test.js
@@ -41,10 +41,18 @@ const mergeReports = ()=>{
   // report the coverage
   execSync("npx nyc report --include 'src/**/*.{js,ts,tsx}' --report-dir coverage --reporter lcov --reporter text --reporter text-summary --check-coverage --colors", {stdio: 'inherit'})
 }
-// dev ran npm test
+// dev ran npm test - exit after running, don't continue to CI/coverage logic
 if(!process.env.CI){
   const args = process.argv.slice(2);
   const result = spawn.sync('react-scripts', ['test'].concat(args), { stdio: 'inherit' })
+  if (result.error) {
+    console.error('Failed to start Jest:', result.error.message);
+    process.exit(1);
+  }
+  if (result.signal) {
+    console.error(`Jest was killed by signal: ${result.signal}`);
+    process.exit(1);
+  }
   process.exit(result.status || 0)
 }
 
@@ -84,6 +92,14 @@ if(jestTestsExist){
   console.log('RUNNING JEST TESTS')
   const args = process.argv.slice(2);
   const result = spawn.sync('react-scripts', ['test', '--coverage', '--colors'].concat(args), { cwd: process.cwd(), stdio: 'inherit' })
+  if (result.error) {
+    console.error('Failed to start Jest:', result.error.message);
+    process.exit(1);
+  }
+  if (result.signal) {
+    console.error(`Jest was killed by signal: ${result.signal}`);
+    process.exit(1);
+  }
   if(result.status) {
     process.exit(result.status)
   }

--- a/packages/react-scripts/scripts/fr-test.js
+++ b/packages/react-scripts/scripts/fr-test.js
@@ -63,7 +63,8 @@ if(cypressTestsExist){
 
 if(jestTestsExist){
   console.log('RUNNING JEST TESTS')
-  execSync('react-scripts test --coverage --colors', { cwd: process.cwd(), stdio: 'inherit' })
+  const args = process.argv.slice(2).join(' ')
+  execSync(`react-scripts test --coverage --colors ${args}`, { cwd: process.cwd(), stdio: 'inherit' })
 }
 
 // If both types exist, merge coverage reports

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -52,7 +52,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     ],
     testEnvironment: 'jsdom',
     transform: {
-      "\\.(gql|graphql)$": "jest-transform-graphql",
+      "\\.(gql|graphql)$": require.resolve("jest-transform-graphql"),
       '^.+\\.(js|jsx|mjs|cjs|ts|tsx)$': resolve(
         'config/jest/babelTransform.js'
       ),


### PR DESCRIPTION
On Linux systems, running Jest tests with the default options can consume all system memory and cause the operating system to crash. Being able to specify how many workers are used makes a huge difference in system stability.

This was tested by manually modifying this script in my `node_modules` directory and running tests in CI mode with the `--maxWorkers=2` option passed in.

In Jest 29 we would be able to use the `JEST_MAX_WORKERS` environment variable, but since we're still on Jest 27 we don't have this option.