### PR TITLE
Convert layout.ejs includes to EJS 3 compatible function form

### DIFF
--- a/CHANGELOG-FRONTIER.md
+++ b/CHANGELOG-FRONTIER.md
@@ -1,3 +1,9 @@
+## 8.16.1
+
+- Convert layout.ejs includes from the removed EJS preprocessor syntax (`<% include x %>`) to the function form (`<%- include('x') %>`) ahead of the company-wide EJS 3 upgrade
+  - The function form renders identically on the current EJS 2 stack, so this is backward compatible and ships before @fs/snow adopts @fs/ejs-mate 3.x
+  - EJS 3 treats the old preprocessor syntax as a SyntaxError, so apps must pick up this layout before the snow-side upgrade
+
 ## 8.16.0
 
 - Enable Jest CLI argument passing through test wrapper scripts (fr-test and conditional-test)

--- a/package-lock.json
+++ b/package-lock.json
@@ -43779,7 +43779,7 @@
     },
     "packages/react-scripts": {
       "name": "@fs/react-scripts",
-      "version": "8.16.0",
+      "version": "8.16.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",

--- a/packages/react-scripts/layout/views/layout.ejs
+++ b/packages/react-scripts/layout/views/layout.ejs
@@ -39,12 +39,12 @@
     <% }) %>
 
     <% if (process.env.NODE_ENV === 'production') { %>
-      <% include partials/dynatrace %>
+      <%- include('partials/dynatrace') %>
     <% } %>
 
     <% if (getFeatureFlag('frontier_snow_unsupportedBrowser').isOn) { %>
       <script>
-        <% include ../modernizr.js %>
+        <%- include('../modernizr.js') %>
       </script>
     <% } %>
 
@@ -61,9 +61,9 @@
         SERVER_DATA.isLoggedIn = <%= isLoggedIn %>
       <% } %>
       SERVER_DATA.flagAttributes = <%- typeof flagAttributes !== 'undefined' ? JSON.stringify(flagAttributes) : JSON.stringify({}) %>;
-      <% include partials/experiments %>
-      <% include partials/sentry %>
-      <% include partials/clientAppConfig %>
+      <%- include('partials/experiments') %>
+      <%- include('partials/sentry') %>
+      <%- include('partials/clientAppConfig') %>
       if (window.dtrum) {
         window.dtrum.enableManualPageDetection()
         if (!window.dtinfo) window.dtinfo = {}
@@ -73,18 +73,18 @@
   </head>
   <body>
     <% if (getFeatureFlag('frontier_snow_unsupportedBrowser').isOn) { %>
-      <% include partials/unsupportedBrowserHeader %>
+      <%- include('partials/unsupportedBrowserHeader') %>
     <% } %>
     <%- body %>
 
     <% if (getFeatureFlag('frontier_snow_unsupportedBrowser').isOn) { %>
       <script>
-        <% include partials/featureDetection %>
+        <%- include('partials/featureDetection') %>
       </script>
     <% } %>
 
     <% if (getFeatureFlag('frontier_snow_browserWarnings').isOn) { %>
-      <% include partials/browserWarnings %>
+      <%- include('partials/browserWarnings') %>
     <% } %>
   </body>
 </html>

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/react-scripts",
-  "version": "8.16.0",
+  "version": "8.16.1",
   "upstreamVersion": "5.0.1",
   "description": "Configuration and scripts for Create React App.",
   "repository": {


### PR DESCRIPTION
## Summary

EJS 3 removes the `<% include %>` preprocessor directive, which layout.ejs used eight times. Converts them to the function form, which renders identically on EJS 2 and EJS 3, so apps can pick this up before snow moves to @fs/ejs-mate 3.x.

## Reasoned Changes

<details>
<summary><b>EJS include syntax conversion in layout.ejs</b></summary>

**What:** All eight preprocessor-style includes (`<% include path %>`) in `packages/react-scripts/layout/views/layout.ejs` are converted to the function form (`<%- include('path') %>`) — covering dynatrace, modernizr, experiments, sentry, clientAppConfig, unsupportedBrowserHeader, featureDetection, and browserWarnings.
**Why:** EJS 3 removed the preprocessor include directive entirely, turning it into a compile-time SyntaxError, and this layout is rendered by every Frontier app through @fs/snow's ejs-mate engine — it would break company-wide the moment @fs/ejs-mate 3.0.0 moves the view engine to EJS 3.1 for the CVE-2022-29078/CVE-2024-33883 fixes. The function form was chosen because it renders identically on EJS 2 and EJS 3, letting this repo ship first so the later snow/ejs-mate upgrade cannot break apps on this syntax; `<%-` (unescaped) is used deliberately since included HTML must not be entity-escaped, and `../modernizr.js` keeps its `.js` extension because EJS appends `.ejs` only to extensionless paths under both versions. `partials/dynatrace.ejs` already uses the function form internally and was left untouched; its views-root-relative internal include path fails identically under plain ejs 2 and 3, so it is version-independent and deferred to the snow repo's EJS3 workplan rather than fixed here.

</details>
<details>
<summary><b>Release plumbing: patch bump and changelog</b></summary>

**What:** `@fs/react-scripts` is bumped from 8.16.0 to 8.16.1 in `packages/react-scripts/package.json` (mirrored in the root `package-lock.json` workspace entry), with a matching CHANGELOG-FRONTIER.md entry.
**Why:** The repo's release convention requires a version bump plus a CHANGELOG-FRONTIER.md entry for every published change, and apps must be able to pick up this layout before the snow-side upgrade lands. A patch bump fits because the function form is backward compatible on the current EJS 2 stack — no behavioral change ships to apps today. The changelog entry explicitly documents the sequencing constraint (apps must adopt this layout before snow adopts @fs/ejs-mate 3.x) so downstream teams understand why an apparently cosmetic template change matters.

</details>

## Risk Assessment

Risk concentrates in the gap between what was verified and what production runs: the EJS 3 path was proven only with plain `ejs.renderFile`, while every real app renders this layout through ejs-mate — an engine whose include path resolution differs (the dynatrace partial's internal include resolves only views-root-relatively). The one include that escapes the views directory, `../modernizr.js`, is exactly where that discrepancy would bite.

### Highest-Risk Areas
1. **packages/react-scripts/layout/views/layout.ejs:47** — `include('../modernizr.js')` escapes the views root, and no end-to-end test exists under ejs-mate 3 + EJS 3 (the e2e run used ejs 2.7.4 + @fs/ejs-mate 2.3.1; @fs/ejs-mate 3.x is not yet published, so EJS 3 was only exercised via a standalone plain-ejs harness). Since ejs-mate resolves some includes views-root-relatively rather than filename-relatively, this parent-directory path is the most plausible include to resolve differently when snow flips the engine.
2. **packages/react-scripts/package.json:3** — the npm registry already carries 8.17.0-alpha.x ahead of this 8.16.1; apps pinned to the alpha line never receive this conversion, and the alpha's dynatrace.ejs has diverged, so if snow's ejs-mate 3 upgrade ships before this fix is ported to the alpha line, alpha-consuming apps hard-fail with a template SyntaxError.
3. **packages/react-scripts/layout/views/layout.ejs:42-87** — the conversion shifts include failures from compile time to render time inside feature-flag branches: a mispublished package missing the gitignored, prepublishOnly-generated `modernizr.js` (or a renamed partial) now compiles cleanly and only throws when `frontier_snow_unsupportedBrowser` is on for a given app, so a broken publish can pass smoke tests on flag-off apps and surface later in flag-on ones.

## Testing

- Repo-wide grep for remaining preprocessor-style includes (`<%[^-=%]*\binclude\s+[^(]` over `*.ejs`) returns zero hits.
- Standalone harness rendered the converted layout via `ejs.renderFile` with stubbed snow locals under **both ejs 2.7.4 and ejs 3.1.10** — all eight include products present in output (dynatrace script URL, inlined modernizr, `SERVER_DATA.initialDefaultEx`/`sentryDSN`/`clientAppConfig`, unsupported-browser header, featureDetection, nocookies shadow host), with `NODE_ENV=production` exercising the dynatrace branch.
- End-to-end on the current EJS 2 stack: frontier-app-react run locally with this layout and a local snow checkout (ejs 2.7.4 + @fs/ejs-mate 2.3.1) — pages returned 200 and rendered correctly in the browser.
- Known gap: no end-to-end run under ejs-mate 3 (`@fs/ejs-mate@3` is not yet published to the registry) — that verification belongs to the snow-side workplan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)